### PR TITLE
feat: implement session API CRUD and audience join flow (Phase 3)

### DIFF
--- a/apps/api/internal/handler/auth_test.go
+++ b/apps/api/internal/handler/auth_test.go
@@ -89,7 +89,8 @@ func strPtr(s string) *string {
 func setupRouter(t *testing.T) (*mockAuthService, http.Handler) {
 	t.Helper()
 	svc := newMockAuthService()
-	r := router.New(time.Now(), svc, testSecret)
+	sessionSvc := newMockSessionService()
+	r := router.New(time.Now(), svc, sessionSvc, testSecret)
 	return svc, r
 }
 
@@ -130,8 +131,8 @@ func TestCreateSession_NoAuth_Returns401(t *testing.T) {
 	}
 }
 
-// POST /v1/sessions with valid JWT → 200
-func TestCreateSession_ValidJWT_Returns200(t *testing.T) {
+// POST /v1/sessions with valid JWT → 201
+func TestCreateSession_ValidJWT_Returns201(t *testing.T) {
 	_, r := setupRouter(t)
 
 	token := generateTestJWT(t, "550e8400-e29b-41d4-a716-446655440000", "user@example.com", testSecret, 24*time.Hour)
@@ -142,8 +143,8 @@ func TestCreateSession_ValidJWT_Returns200(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -191,16 +192,17 @@ func TestCreateSession_WrongSecret_Returns401(t *testing.T) {
 	}
 }
 
-// GET /v1/sessions/:code without JWT → 200 (public)
-func TestGetSession_NoAuth_Returns200(t *testing.T) {
+// GET /v1/sessions/:code without JWT → 404 when session doesn't exist (public route, no auth needed)
+func TestGetSession_NoAuth_PublicRoute(t *testing.T) {
 	_, r := setupRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/ABC123", nil)
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d", rec.Code)
+	// Route is public (no 401), but session doesn't exist → 404
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
 	}
 }
 

--- a/apps/api/internal/handler/session.go
+++ b/apps/api/internal/handler/session.go
@@ -1,1 +1,174 @@
 package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/middleware"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+)
+
+// SessionServiceInterface defines the interface the session handler depends on.
+type SessionServiceInterface interface {
+	CreateSession(hostID uuid.UUID, title string) (*models.Session, error)
+	ListSessionsByHost(hostID uuid.UUID) ([]models.Session, error)
+	GetSessionByCode(code string) (*models.Session, error)
+	JoinSession(ctx context.Context, code, clientID string) (string, *models.Session, error)
+}
+
+type SessionHandler struct {
+	svc SessionServiceInterface
+}
+
+func NewSessionHandler(svc SessionServiceInterface) *SessionHandler {
+	return &SessionHandler{svc: svc}
+}
+
+type createSessionRequest struct {
+	Title string `json:"title"`
+}
+
+type createSessionResponse struct {
+	ID        string `json:"id"`
+	Code      string `json:"code"`
+	Title     string `json:"title"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
+}
+
+type joinSessionResponse struct {
+	AudienceUID  string `json:"audience_uid"`
+	SessionTitle string `json:"session_title"`
+}
+
+// Create handles POST /v1/sessions
+func (h *SessionHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req createSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid request body",
+		})
+		return
+	}
+
+	if req.Title == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "title is required",
+		})
+		return
+	}
+
+	userID := middleware.UserIDFromContext(r.Context())
+	hostID, err := uuid.Parse(userID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid user id",
+		})
+		return
+	}
+
+	session, err := h.svc.CreateSession(hostID, req.Title)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":   "internal",
+			"message": "failed to create session",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, createSessionResponse{
+		ID:        session.ID.String(),
+		Code:      session.Code,
+		Title:     session.Title,
+		Status:    session.Status,
+		CreatedAt: session.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	})
+}
+
+// List handles GET /v1/sessions (authenticated)
+func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.UserIDFromContext(r.Context())
+	hostID, err := uuid.Parse(userID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid user id",
+		})
+		return
+	}
+
+	sessions, err := h.svc.ListSessionsByHost(hostID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":   "internal",
+			"message": "failed to list sessions",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sessions)
+}
+
+// GetByCode handles GET /v1/sessions/:code (public)
+func (h *SessionHandler) GetByCode(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	if code == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "code is required",
+		})
+		return
+	}
+
+	session, err := h.svc.GetSessionByCode(code)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":   "not_found",
+			"message": "session not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, session)
+}
+
+// Join handles POST /v1/sessions/:code/join (public)
+func (h *SessionHandler) Join(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	if code == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "code is required",
+		})
+		return
+	}
+
+	clientID := r.Header.Get("X-Client-ID")
+
+	uid, session, err := h.svc.JoinSession(r.Context(), code, clientID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":   "not_found",
+			"message": "session not found",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, joinSessionResponse{
+		AudienceUID:  uid,
+		SessionTitle: session.Title,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/apps/api/internal/handler/session_test.go
+++ b/apps/api/internal/handler/session_test.go
@@ -1,0 +1,420 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/router"
+)
+
+// --- mock session service ------------------------------------------------
+
+type mockSessionService struct {
+	mu       sync.Mutex
+	sessions map[string]*models.Session // keyed by code
+	byHost   map[string][]string        // hostID → []code
+	audience map[string]string          // "code:clientID" → uid
+	uidKeys  map[string]time.Duration   // "audience:code:uid" → TTL
+}
+
+func newMockSessionService() *mockSessionService {
+	return &mockSessionService{
+		sessions: make(map[string]*models.Session),
+		byHost:   make(map[string][]string),
+		audience: make(map[string]string),
+		uidKeys:  make(map[string]time.Duration),
+	}
+}
+
+func (m *mockSessionService) CreateSession(hostID uuid.UUID, title string) (*models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Generate a simple code for testing
+	code := generateMockCode(m.sessions)
+
+	session := &models.Session{
+		ID:        uuid.New(),
+		HostID:    &hostID,
+		Code:      code,
+		Title:     title,
+		Status:    "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	m.sessions[code] = session
+	m.byHost[hostID.String()] = append(m.byHost[hostID.String()], code)
+	return session, nil
+}
+
+func (m *mockSessionService) ListSessionsByHost(hostID uuid.UUID) ([]models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	codes := m.byHost[hostID.String()]
+	var result []models.Session
+	// Return in reverse order (newest first)
+	for i := len(codes) - 1; i >= 0; i-- {
+		if s, ok := m.sessions[codes[i]]; ok {
+			result = append(result, *s)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockSessionService) GetSessionByCode(code string) (*models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[code]
+	if !ok {
+		return nil, fmt.Errorf("session not found")
+	}
+	return s, nil
+}
+
+func (m *mockSessionService) JoinSession(ctx context.Context, code, clientID string) (string, *models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[code]
+	if !ok {
+		return "", nil, fmt.Errorf("session not found")
+	}
+
+	// Check for existing mapping
+	if clientID != "" {
+		key := code + ":" + clientID
+		if uid, exists := m.audience[key]; exists {
+			return uid, s, nil
+		}
+	}
+
+	uid := uuid.New().String()
+
+	// Store audience:{code}:{uid} key
+	uidKey := "audience:" + code + ":" + uid
+	m.uidKeys[uidKey] = 24 * time.Hour
+
+	if clientID != "" {
+		m.audience[code+":"+clientID] = uid
+	}
+
+	return uid, s, nil
+}
+
+func generateMockCode(existing map[string]*models.Session) string {
+	charset := "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	// Simple incrementing code for testing determinism
+	n := len(existing)
+	code := make([]byte, 6)
+	for i := 5; i >= 0; i-- {
+		code[i] = charset[n%len(charset)]
+		n /= len(charset)
+	}
+	return string(code)
+}
+
+// --- acceptance tests --------------------------------------------------
+
+// POST /v1/sessions with {title} → returns {id, code, title, status: "active"}
+func TestCreateSession_Success(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	token := generateTestJWT(t, uuid.New().String(), "host@example.com", testSecret, 24*time.Hour)
+	body := bytes.NewBufferString(`{"title": "CS101 Lecture"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", body)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("expected non-empty id")
+	}
+	if resp["title"] != "CS101 Lecture" {
+		t.Errorf("expected title=CS101 Lecture, got %v", resp["title"])
+	}
+	if resp["status"] != "active" {
+		t.Errorf("expected status=active, got %v", resp["status"])
+	}
+
+	// Code is exactly 6 alphanumeric uppercase characters
+	code, ok := resp["code"].(string)
+	if !ok || len(code) != 6 {
+		t.Fatalf("expected 6-char code, got %q", code)
+	}
+	matched, _ := regexp.MatchString(`^[A-Z0-9]{6}$`, code)
+	if !matched {
+		t.Errorf("code %q does not match ^[A-Z0-9]{6}$", code)
+	}
+}
+
+// Creating a session without auth → 401
+func TestCreateSession_NoAuth_Returns401_Session(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	body := bytes.NewBufferString(`{"title": "No Auth Session"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions", body)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+// Creating 100 sessions produces 100 unique codes
+func TestCreateSession_UniqueCodesFor100(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	token := generateTestJWT(t, uuid.New().String(), "host@example.com", testSecret, 24*time.Hour)
+	codes := make(map[string]bool)
+
+	for i := 0; i < 100; i++ {
+		body := bytes.NewBufferString(`{"title": "Session"}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/sessions", body)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("session %d: expected 201, got %d", i, rec.Code)
+		}
+
+		var resp map[string]interface{}
+		json.NewDecoder(rec.Body).Decode(&resp)
+		code := resp["code"].(string)
+		if codes[code] {
+			t.Fatalf("duplicate code %q at session %d", code, i)
+		}
+		codes[code] = true
+	}
+
+	if len(codes) != 100 {
+		t.Errorf("expected 100 unique codes, got %d", len(codes))
+	}
+}
+
+// GET /v1/sessions/:code → returns session details (no auth needed)
+func TestGetSessionByCode_Public(t *testing.T) {
+	_, sessionSvc, r := setupRouterWithSession(t)
+
+	// Create a session in the mock
+	hostID := uuid.New()
+	session, _ := sessionSvc.CreateSession(hostID, "Public Session")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+session.Code, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["title"] != "Public Session" {
+		t.Errorf("expected title=Public Session, got %v", resp["title"])
+	}
+}
+
+// GET /v1/sessions/XXXXXX (invalid code) → 404
+func TestGetSessionByCode_NotFound(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions/XXXXXX", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// GET /v1/sessions with auth → returns list sorted by created_at DESC
+func TestListSessions_WithAuth(t *testing.T) {
+	_, sessionSvc, r := setupRouterWithSession(t)
+
+	hostID := uuid.New()
+	sessionSvc.CreateSession(hostID, "Session 1")
+	time.Sleep(time.Millisecond) // ensure ordering
+	sessionSvc.CreateSession(hostID, "Session 2")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var sessions []map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&sessions)
+
+	if len(sessions) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(sessions))
+	}
+
+	// Newest first
+	if sessions[0]["title"] != "Session 2" {
+		t.Errorf("expected first session to be Session 2, got %v", sessions[0]["title"])
+	}
+}
+
+// GET /v1/sessions without auth → 401
+func TestListSessions_NoAuth_Returns401(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sessions", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rec.Code)
+	}
+}
+
+// POST /v1/sessions/:code/join → returns {audience_uid} and creates Redis key
+func TestJoinSession_Success(t *testing.T) {
+	_, sessionSvc, r := setupRouterWithSession(t)
+
+	hostID := uuid.New()
+	session, _ := sessionSvc.CreateSession(hostID, "Join Test")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+session.Code+"/join", nil)
+	req.Header.Set("X-Client-ID", "client-123")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	uid, ok := resp["audience_uid"].(string)
+	if !ok || uid == "" {
+		t.Fatal("expected non-empty audience_uid")
+	}
+
+	if resp["session_title"] != "Join Test" {
+		t.Errorf("expected session_title=Join Test, got %v", resp["session_title"])
+	}
+
+	// Verify Redis key with TTL exists in mock
+	uidKey := "audience:" + session.Code + ":" + uid
+	ttl, exists := sessionSvc.uidKeys[uidKey]
+	if !exists {
+		t.Error("expected audience UID key in Redis")
+	}
+	if ttl != 24*time.Hour {
+		t.Errorf("expected TTL=24h, got %v", ttl)
+	}
+}
+
+// Calling join again with same client ID → returns SAME uid (idempotent)
+func TestJoinSession_Idempotent(t *testing.T) {
+	_, sessionSvc, r := setupRouterWithSession(t)
+
+	hostID := uuid.New()
+	session, _ := sessionSvc.CreateSession(hostID, "Idempotent Test")
+
+	// First join
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+session.Code+"/join", nil)
+	req.Header.Set("X-Client-ID", "client-abc")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var resp1 map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp1)
+	uid1 := resp1["audience_uid"].(string)
+
+	// Second join — same client ID
+	req = httptest.NewRequest(http.MethodPost, "/v1/sessions/"+session.Code+"/join", nil)
+	req.Header.Set("X-Client-ID", "client-abc")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var resp2 map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp2)
+	uid2 := resp2["audience_uid"].(string)
+
+	if uid1 != uid2 {
+		t.Errorf("expected same uid on second join, got %q and %q", uid1, uid2)
+	}
+}
+
+// Different client joining → gets DIFFERENT uid
+func TestJoinSession_DifferentClients(t *testing.T) {
+	_, sessionSvc, r := setupRouterWithSession(t)
+
+	hostID := uuid.New()
+	session, _ := sessionSvc.CreateSession(hostID, "Multi Client Test")
+
+	// Client 1
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+session.Code+"/join", nil)
+	req.Header.Set("X-Client-ID", "client-1")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	var resp1 map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp1)
+
+	// Client 2
+	req = httptest.NewRequest(http.MethodPost, "/v1/sessions/"+session.Code+"/join", nil)
+	req.Header.Set("X-Client-ID", "client-2")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	var resp2 map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp2)
+
+	if resp1["audience_uid"] == resp2["audience_uid"] {
+		t.Error("expected different UIDs for different clients")
+	}
+}
+
+// Join invalid session → 404
+func TestJoinSession_NotFound(t *testing.T) {
+	_, _, r := setupRouterWithSession(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/ZZZZZZ/join", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// --- helper to set up router with both mocks ---
+
+func setupRouterWithSession(t *testing.T) (*mockAuthService, *mockSessionService, http.Handler) {
+	t.Helper()
+	authSvc := newMockAuthService()
+	sessionSvc := newMockSessionService()
+	r := router.New(time.Now(), authSvc, sessionSvc, testSecret)
+	return authSvc, sessionSvc, r
+}

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Eahtasham/live-pulse/apps/api/internal/middleware"
 )
 
-func New(startTime time.Time, authSvc handler.AuthService, jwtSecret string) *chi.Mux {
+func New(startTime time.Time, authSvc handler.AuthService, sessionSvc handler.SessionServiceInterface, jwtSecret string) *chi.Mux {
 	r := chi.NewRouter()
 
 	// Global middleware
@@ -23,7 +23,7 @@ func New(startTime time.Time, authSvc handler.AuthService, jwtSecret string) *ch
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"http://localhost:3000"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Client-ID"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
 		MaxAge:           300,
@@ -33,19 +33,22 @@ func New(startTime time.Time, authSvc handler.AuthService, jwtSecret string) *ch
 	r.Get("/healthz", handler.Health(startTime))
 
 	authHandler := handler.NewAuthHandler(authSvc)
+	sessionHandler := handler.NewSessionHandler(sessionSvc)
 
 	r.Route("/v1", func(r chi.Router) {
 		// Public routes — no JWT required
 		r.Post("/auth/callback", authHandler.Callback)
 		r.Post("/auth/register", authHandler.Register)
 		r.Post("/auth/login", authHandler.Login)
-		r.Get("/sessions/{code}", placeholderHandler) // public: join by code
+		r.Get("/sessions/{code}", sessionHandler.GetByCode)
+		r.Post("/sessions/{code}/join", sessionHandler.Join)
 		// TODO: vote endpoints, Q&A submission endpoints (public)
 
 		// Protected routes — JWT required
 		r.Group(func(r chi.Router) {
 			r.Use(middleware.JWTAuth(jwtSecret))
-			r.Post("/sessions", placeholderHandler)
+			r.Post("/sessions", sessionHandler.Create)
+			r.Get("/sessions", sessionHandler.List)
 			r.Patch("/sessions/{id}", placeholderHandler)
 			r.Delete("/sessions/{id}", placeholderHandler)
 		})

--- a/apps/api/internal/service/session.go
+++ b/apps/api/internal/service/session.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"gorm.io/gorm"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+)
+
+const (
+	codeCharset    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	codeLength     = 6
+	maxCodeRetries = 10
+	audienceTTL    = 24 * time.Hour
+)
+
+type SessionService struct {
+	db  *gorm.DB
+	rdb *redis.Client
+}
+
+func NewSessionService(db *gorm.DB, rdb *redis.Client) *SessionService {
+	return &SessionService{db: db, rdb: rdb}
+}
+
+// CreateSession creates a new session with a unique 6-char code.
+func (s *SessionService) CreateSession(hostID uuid.UUID, title string) (*models.Session, error) {
+	code, err := s.generateUniqueCode()
+	if err != nil {
+		return nil, fmt.Errorf("generate code: %w", err)
+	}
+
+	session := models.Session{
+		HostID: &hostID,
+		Code:   code,
+		Title:  title,
+		Status: "active",
+	}
+
+	if err := s.db.Create(&session).Error; err != nil {
+		return nil, fmt.Errorf("create session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// ListSessionsByHost returns all sessions for a given host, sorted by created_at DESC.
+func (s *SessionService) ListSessionsByHost(hostID uuid.UUID) ([]models.Session, error) {
+	var sessions []models.Session
+	if err := s.db.Where("host_id = ?", hostID).Order("created_at DESC").Find(&sessions).Error; err != nil {
+		return nil, fmt.Errorf("list sessions: %w", err)
+	}
+	return sessions, nil
+}
+
+// GetSessionByCode returns a session by its 6-char code.
+func (s *SessionService) GetSessionByCode(code string) (*models.Session, error) {
+	var session models.Session
+	if err := s.db.Where("code = ?", code).First(&session).Error; err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+// JoinSession returns an existing or new audience UID for a client+session pair.
+func (s *SessionService) JoinSession(ctx context.Context, code, clientID string) (string, *models.Session, error) {
+	session, err := s.GetSessionByCode(code)
+	if err != nil {
+		return "", nil, err
+	}
+
+	// If client ID provided, check for existing UID
+	if clientID != "" {
+		redisKey := fmt.Sprintf("audience:%s:client:%s", code, clientID)
+		existing, err := s.rdb.Get(ctx, redisKey).Result()
+		if err == nil && existing != "" {
+			return existing, session, nil
+		}
+	}
+
+	// Generate new UID
+	uid := uuid.New().String()
+
+	// Store audience:{code}:{uid} with TTL
+	uidKey := fmt.Sprintf("audience:%s:%s", code, uid)
+	if err := s.rdb.Set(ctx, uidKey, "1", audienceTTL).Err(); err != nil {
+		return "", nil, fmt.Errorf("store audience uid: %w", err)
+	}
+
+	// If client ID provided, map client→uid for idempotency
+	if clientID != "" {
+		clientKey := fmt.Sprintf("audience:%s:client:%s", code, clientID)
+		if err := s.rdb.Set(ctx, clientKey, uid, audienceTTL).Err(); err != nil {
+			return "", nil, fmt.Errorf("store client mapping: %w", err)
+		}
+	}
+
+	return uid, session, nil
+}
+
+func (s *SessionService) generateUniqueCode() (string, error) {
+	charsetLen := big.NewInt(int64(len(codeCharset)))
+
+	for attempt := 0; attempt < maxCodeRetries; attempt++ {
+		code := make([]byte, codeLength)
+		for i := range code {
+			idx, err := rand.Int(rand.Reader, charsetLen)
+			if err != nil {
+				return "", fmt.Errorf("crypto rand: %w", err)
+			}
+			code[i] = codeCharset[idx.Int64()]
+		}
+
+		candidate := string(code)
+
+		// Check DB uniqueness
+		var count int64
+		if err := s.db.Model(&models.Session{}).Where("code = ?", candidate).Count(&count).Error; err != nil {
+			return "", fmt.Errorf("check code uniqueness: %w", err)
+		}
+		if count == 0 {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to generate unique code after %d attempts", maxCodeRetries)
+}

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -42,7 +42,8 @@ func main() {
 
 	startTime := time.Now()
 	svc := service.New(gormDB, cfg.JWTSecret, cfg.JWTExpiry)
-	r := router.New(startTime, svc, cfg.JWTSecret)
+	sessionSvc := service.NewSessionService(gormDB, rdb)
+	r := router.New(startTime, svc, sessionSvc, cfg.JWTSecret)
 
 	srv := &http.Server{
 		Addr:         ":" + cfg.APIPort,

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,10 +1,40 @@
 "use client";
 
 import { useSession, signOut } from "next-auth/react";
+import { useEffect, useState, useCallback } from "react";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { CreateSessionDialog } from "@/components/session/create-session-dialog";
+import { SessionCard } from "@/components/session/session-card";
+import type { Session } from "@/lib/api";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 export default function DashboardPage() {
-  const { data: session, status } = useSession();
+  const { data: authSession, status } = useSession();
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchSessions = useCallback(async () => {
+    if (!authSession?.apiToken) return;
+    try {
+      const res = await fetch(`${apiUrl}/v1/sessions`, {
+        headers: {
+          Authorization: `Bearer ${authSession.apiToken}`,
+          "Content-Type": "application/json",
+        },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setSessions(data ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [authSession?.apiToken]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
 
   if (status === "loading") {
     return (
@@ -24,9 +54,9 @@ export default function DashboardPage() {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          {session?.user && (
+          {authSession?.user && (
             <span className="text-sm text-zinc-600 dark:text-zinc-400">
-              {session.user.email}
+              {authSession.user.email}
             </span>
           )}
           <ThemeToggle />
@@ -37,6 +67,28 @@ export default function DashboardPage() {
             Sign out
           </button>
         </div>
+      </div>
+
+      <div className="mt-8 flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Your Sessions</h2>
+        <CreateSessionDialog
+          token={authSession?.apiToken ?? ""}
+          onCreated={fetchSessions}
+        />
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {loading ? (
+          <p className="text-sm text-muted-foreground col-span-full">
+            Loading sessions...
+          </p>
+        ) : sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground col-span-full">
+            No sessions yet. Create one to get started!
+          </p>
+        ) : (
+          sessions.map((s) => <SessionCard key={s.id} session={s} />)
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/session/[code]/page.tsx
+++ b/apps/web/app/session/[code]/page.tsx
@@ -1,3 +1,5 @@
+import { SessionJoinView } from "@/components/session/session-join-view";
+
 export default async function SessionPage({
   params,
 }: {
@@ -5,10 +7,5 @@ export default async function SessionPage({
 }) {
   const { code } = await params;
 
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center">
-      <h1 className="text-3xl font-bold">Session: {code}</h1>
-      <p className="mt-2 text-gray-500">Audience view — polls &amp; Q&amp;A will appear here</p>
-    </div>
-  );
+  return <SessionJoinView code={code} />;
 }

--- a/apps/web/components/session/create-session-dialog.tsx
+++ b/apps/web/components/session/create-session-dialog.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface Props {
+  token: string;
+  onCreated: () => void;
+}
+
+export function CreateSessionDialog({ token, onCreated }: Props) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch(`${apiUrl}/v1/sessions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title: title.trim() }),
+      });
+
+      if (!res.ok) {
+        setError("Failed to create session");
+        setLoading(false);
+        return;
+      }
+
+      setTitle("");
+      setOpen(false);
+      onCreated();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 12h14" />
+            <path d="M12 5v14" />
+          </svg>
+          New Session
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a new session</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleCreate} className="space-y-4">
+          {error && (
+            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+              {error}
+            </p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="session-title">Session title</Label>
+            <Input
+              id="session-title"
+              placeholder="e.g. CS101 Lecture 5"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              autoFocus
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading || !title.trim()}>
+              {loading ? "Creating..." : "Create"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/session/session-card.tsx
+++ b/apps/web/components/session/session-card.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { Session } from "@/lib/api";
+
+export function SessionCard({ session }: { session: Session }) {
+  const [copied, setCopied] = useState(false);
+
+  const joinUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/session/${session.code}`
+      : `/session/${session.code}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(joinUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div className="space-y-1">
+          <CardTitle className="text-lg">{session.title}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Code:{" "}
+            <span className="font-mono font-semibold tracking-wider">
+              {session.code}
+            </span>
+          </p>
+        </div>
+        <Badge variant={session.status === "active" ? "default" : "secondary"}>
+          {session.status}
+        </Badge>
+      </CardHeader>
+      <CardContent className="flex items-center gap-2">
+        <code className="flex-1 truncate rounded-md bg-muted px-3 py-2 text-sm">
+          {joinUrl}
+        </code>
+        <Button variant="outline" size="sm" onClick={handleCopy}>
+          {copied ? (
+            <>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M20 6 9 17l-5-5" />
+              </svg>
+              Copied
+            </>
+          ) : (
+            <>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+              </svg>
+              Copy Link
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/session/session-join-view.tsx
+++ b/apps/web/components/session/session-join-view.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+function getClientId(): string {
+  const key = "livepulse_client_id";
+  let id = localStorage.getItem(key);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(key, id);
+  }
+  return id;
+}
+
+export function SessionJoinView({ code }: { code: string }) {
+  const [status, setStatus] = useState<"loading" | "joined" | "error">(
+    "loading"
+  );
+  const [sessionTitle, setSessionTitle] = useState("");
+  const [audienceUid, setAudienceUid] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function join() {
+      try {
+        const clientId = getClientId();
+        const res = await fetch(
+          `${apiUrl}/v1/sessions/${encodeURIComponent(code)}/join`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Client-ID": clientId,
+            },
+          }
+        );
+
+        if (!res.ok) {
+          setError("Session not found");
+          setStatus("error");
+          return;
+        }
+
+        const data = await res.json();
+        setSessionTitle(data.session_title);
+        setAudienceUid(data.audience_uid);
+        setStatus("joined");
+      } catch {
+        setError("Unable to connect");
+        setStatus("error");
+      }
+    }
+
+    join();
+  }, [code]);
+
+  if (status === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-muted-foreground">Joining session...</p>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <h1 className="text-2xl font-bold text-destructive">
+          {error}
+        </h1>
+        <p className="text-muted-foreground">
+          Check your session code and try again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">{sessionTitle}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Session code:{" "}
+            <span className="font-mono font-semibold tracking-wider">
+              {code}
+            </span>
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4 text-center">
+          <div className="rounded-lg bg-primary/10 px-4 py-3">
+            <p className="text-sm font-medium text-primary">
+              You&apos;ve joined the session!
+            </p>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Polls and Q&amp;A will appear here when the host starts them.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Your audience ID:{" "}
+            <code className="font-mono">{audienceUid.slice(0, 8)}…</code>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -22,3 +22,60 @@ export async function apiFetch(
     headers,
   })
 }
+
+// ── Session types ────────────────────────────────────────────────────
+
+export interface Session {
+  id: string
+  code: string
+  title: string
+  status: string
+  created_at: string
+  host_id?: string
+}
+
+export interface JoinResponse {
+  audience_uid: string
+  session_title: string
+}
+
+// ── Session API (server-side, uses auth) ─────────────────────────────
+
+export async function createSession(title: string): Promise<Session> {
+  const res = await apiFetch("/v1/sessions", {
+    method: "POST",
+    body: JSON.stringify({ title }),
+  })
+  if (!res.ok) throw new Error("Failed to create session")
+  return res.json()
+}
+
+export async function listSessions(): Promise<Session[]> {
+  const res = await apiFetch("/v1/sessions")
+  if (!res.ok) throw new Error("Failed to list sessions")
+  return res.json()
+}
+
+export async function getSessionByCode(code: string): Promise<Session> {
+  const res = await fetch(`${API_URL}/v1/sessions/${encodeURIComponent(code)}`, {
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+  })
+  if (!res.ok) throw new Error("Session not found")
+  return res.json()
+}
+
+export async function joinSession(
+  code: string,
+  clientId: string
+): Promise<JoinResponse> {
+  const res = await fetch(`${API_URL}/v1/sessions/${encodeURIComponent(code)}/join`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Client-ID": clientId,
+    },
+  })
+  if (!res.ok) throw new Error("Failed to join session")
+  return res.json()
+}


### PR DESCRIPTION
- Add session service with crypto/rand 6-char code generation and Redis-backed audience join
- Add session handler with Create, List, GetByCode, Join endpoints
- Wire session routes in router (public: GET /sessions/:code, POST /sessions/:code/join; protected: POST /sessions, GET /sessions)
- Add 11 acceptance tests covering all session endpoints
- Update dashboard with create session dialog and session cards with share link
- Add public session join page with auto-join and persistent client ID
- Add shadcn UI components (input, label, dialog, card, badge)

Closes #4