### PR TITLE
feat: implement poll API, auth UI, session UI, and poll UI

### DIFF
--- a/apps/api/internal/handler/auth_test.go
+++ b/apps/api/internal/handler/auth_test.go
@@ -90,7 +90,7 @@ func setupRouter(t *testing.T) (*mockAuthService, http.Handler) {
 	t.Helper()
 	svc := newMockAuthService()
 	sessionSvc := newMockSessionService()
-	r := router.New(time.Now(), svc, sessionSvc, testSecret)
+	r := router.New(time.Now(), svc, sessionSvc, nil, testSecret)
 	return svc, r
 }
 

--- a/apps/api/internal/handler/poll.go
+++ b/apps/api/internal/handler/poll.go
@@ -1,1 +1,308 @@
 package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/middleware"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/service"
+)
+
+// PollServiceInterface defines the interface the poll handler depends on.
+type PollServiceInterface interface {
+	CreatePoll(sessionCode string, hostID uuid.UUID, question, answerMode string, timeLimitSec *int, options []models.PollOption) (*models.Poll, error)
+	ListPolls(sessionCode string, isHost bool) ([]models.Poll, error)
+	GetPoll(sessionCode string, pollID uuid.UUID) (*models.Poll, map[uuid.UUID]int64, error)
+	UpdatePollStatus(sessionCode string, pollID, hostID uuid.UUID, newStatus string) (*models.Poll, error)
+	GetSessionByCode(code string) (*models.Session, error)
+}
+
+type PollHandler struct {
+	svc PollServiceInterface
+}
+
+func NewPollHandler(svc PollServiceInterface) *PollHandler {
+	return &PollHandler{svc: svc}
+}
+
+type createPollRequest struct {
+	Question     string             `json:"question"`
+	AnswerMode   string             `json:"answer_mode"`
+	TimeLimitSec *int               `json:"time_limit_sec"`
+	Options      []createPollOption `json:"options"`
+}
+
+type createPollOption struct {
+	Label    string `json:"label"`
+	Position int16  `json:"position"`
+}
+
+type pollOptionResponse struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Position  int16  `json:"position"`
+	VoteCount int64  `json:"vote_count"`
+}
+
+type pollResponse struct {
+	ID           string               `json:"id"`
+	SessionID    string               `json:"session_id"`
+	Question     string               `json:"question"`
+	AnswerMode   string               `json:"answer_mode"`
+	Status       string               `json:"status"`
+	TimeLimitSec *int                 `json:"time_limit_sec"`
+	Options      []pollOptionResponse `json:"options"`
+	CreatedAt    string               `json:"created_at"`
+	UpdatedAt    string               `json:"updated_at"`
+}
+
+type updatePollRequest struct {
+	Status string `json:"status"`
+}
+
+func toPollResponse(p *models.Poll, voteCounts map[uuid.UUID]int64) pollResponse {
+	opts := make([]pollOptionResponse, len(p.Options))
+	for i, o := range p.Options {
+		var vc int64
+		if voteCounts != nil {
+			vc = voteCounts[o.ID]
+		}
+		opts[i] = pollOptionResponse{
+			ID:        o.ID.String(),
+			Label:     o.Label,
+			Position:  o.Position,
+			VoteCount: vc,
+		}
+	}
+	return pollResponse{
+		ID:           p.ID.String(),
+		SessionID:    p.SessionID.String(),
+		Question:     p.Question,
+		AnswerMode:   p.AnswerMode,
+		Status:       p.Status,
+		TimeLimitSec: p.TimeLimitSec,
+		Options:      opts,
+		CreatedAt:    p.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:    p.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+// Create handles POST /v1/sessions/:code/polls
+func (h *PollHandler) Create(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+
+	userID := middleware.UserIDFromContext(r.Context())
+	hostID, err := uuid.Parse(userID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid user id",
+		})
+		return
+	}
+
+	var req createPollRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid request body",
+		})
+		return
+	}
+
+	// Convert options
+	options := make([]models.PollOption, len(req.Options))
+	for i, o := range req.Options {
+		options[i] = models.PollOption{
+			Label:    o.Label,
+			Position: o.Position,
+		}
+	}
+
+	poll, err := h.svc.CreatePoll(code, hostID, req.Question, req.AnswerMode, req.TimeLimitSec, options)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrSessionNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "session not found",
+			})
+		case errors.Is(err, service.ErrSessionArchived):
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":   "bad_request",
+				"message": "cannot create poll in archived session",
+			})
+		case errors.Is(err, service.ErrNotSessionHost):
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":   "forbidden",
+				"message": "only the session host can create polls",
+			})
+		case errors.Is(err, service.ErrInvalidInput):
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":   "bad_request",
+				"message": err.Error(),
+			})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{
+				"error":   "internal",
+				"message": "failed to create poll",
+			})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, toPollResponse(poll, nil))
+}
+
+// List handles GET /v1/sessions/:code/polls
+func (h *PollHandler) List(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+
+	// Determine if the requester is the host
+	isHost := false
+	userID := middleware.UserIDFromContext(r.Context())
+	if userID != "" {
+		hostID, err := uuid.Parse(userID)
+		if err == nil {
+			session, err := h.svc.GetSessionByCode(code)
+			if err == nil && session.HostID != nil && *session.HostID == hostID {
+				isHost = true
+			}
+		}
+	}
+
+	polls, err := h.svc.ListPolls(code, isHost)
+	if err != nil {
+		if errors.Is(err, service.ErrSessionNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "session not found",
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{
+			"error":   "internal",
+			"message": "failed to list polls",
+		})
+		return
+	}
+
+	result := make([]pollResponse, len(polls))
+	for i, p := range polls {
+		result[i] = toPollResponse(&p, nil)
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// Get handles GET /v1/sessions/:code/polls/:pollID
+func (h *PollHandler) Get(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	pollIDStr := chi.URLParam(r, "pollID")
+
+	pollID, err := uuid.Parse(pollIDStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid poll id",
+		})
+		return
+	}
+
+	poll, voteCounts, err := h.svc.GetPoll(code, pollID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrSessionNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "session not found",
+			})
+		case errors.Is(err, service.ErrPollNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "poll not found",
+			})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{
+				"error":   "internal",
+				"message": "failed to get poll",
+			})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toPollResponse(poll, voteCounts))
+}
+
+// Update handles PATCH /v1/sessions/:code/polls/:pollID
+func (h *PollHandler) Update(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	pollIDStr := chi.URLParam(r, "pollID")
+
+	userID := middleware.UserIDFromContext(r.Context())
+	hostID, err := uuid.Parse(userID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid user id",
+		})
+		return
+	}
+
+	pollID, err := uuid.Parse(pollIDStr)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid poll id",
+		})
+		return
+	}
+
+	var req updatePollRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error":   "bad_request",
+			"message": "invalid request body",
+		})
+		return
+	}
+
+	poll, err := h.svc.UpdatePollStatus(code, pollID, hostID, req.Status)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrSessionNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "session not found",
+			})
+		case errors.Is(err, service.ErrNotSessionHost):
+			writeJSON(w, http.StatusForbidden, map[string]string{
+				"error":   "forbidden",
+				"message": "only the session host can modify polls",
+			})
+		case errors.Is(err, service.ErrPollNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error":   "not_found",
+				"message": "poll not found",
+			})
+		case errors.Is(err, service.ErrInvalidTransition):
+			writeJSON(w, http.StatusBadRequest, map[string]string{
+				"error":   "bad_request",
+				"message": err.Error(),
+			})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{
+				"error":   "internal",
+				"message": "failed to update poll",
+			})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toPollResponse(poll, nil))
+}

--- a/apps/api/internal/handler/poll_test.go
+++ b/apps/api/internal/handler/poll_test.go
@@ -1,0 +1,784 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/router"
+	"github.com/Eahtasham/live-pulse/apps/api/internal/service"
+)
+
+// --- mock poll service ---------------------------------------------------
+
+type mockPollService struct {
+	mu        sync.Mutex
+	sessions  map[string]*models.Session // code → session
+	polls     map[uuid.UUID]*models.Poll // pollID → poll
+	bySession map[uuid.UUID][]uuid.UUID  // sessionID → []pollID
+}
+
+func newMockPollService() *mockPollService {
+	return &mockPollService{
+		sessions:  make(map[string]*models.Session),
+		polls:     make(map[uuid.UUID]*models.Poll),
+		bySession: make(map[uuid.UUID][]uuid.UUID),
+	}
+}
+
+func (m *mockPollService) addSession(code string, hostID uuid.UUID, status string) *models.Session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := &models.Session{
+		ID:        uuid.New(),
+		HostID:    &hostID,
+		Code:      code,
+		Title:     "Test Session",
+		Status:    status,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	m.sessions[code] = s
+	return s
+}
+
+func (m *mockPollService) GetSessionByCode(code string) (*models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[code]
+	if !ok {
+		return nil, service.ErrSessionNotFound
+	}
+	return s, nil
+}
+
+func (m *mockPollService) CreatePoll(sessionCode string, hostID uuid.UUID, question, answerMode string, timeLimitSec *int, options []models.PollOption) (*models.Poll, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionCode]
+	if !ok {
+		return nil, service.ErrSessionNotFound
+	}
+	if s.Status == "archived" {
+		return nil, service.ErrSessionArchived
+	}
+	if s.HostID == nil || *s.HostID != hostID {
+		return nil, service.ErrNotSessionHost
+	}
+
+	// Validate
+	if question == "" || len(question) > 500 {
+		return nil, fmt.Errorf("%w: question is required and must be at most 500 characters", service.ErrInvalidInput)
+	}
+	if answerMode != "single" && answerMode != "multi" {
+		return nil, fmt.Errorf("%w: answer_mode must be 'single' or 'multi'", service.ErrInvalidInput)
+	}
+	if len(options) < 2 || len(options) > 6 {
+		return nil, fmt.Errorf("%w: options must be between 2 and 6", service.ErrInvalidInput)
+	}
+	for _, o := range options {
+		if o.Label == "" || len(o.Label) > 200 {
+			return nil, fmt.Errorf("%w: option label is required and must be at most 200 characters", service.ErrInvalidInput)
+		}
+	}
+	if timeLimitSec != nil && *timeLimitSec <= 0 {
+		return nil, fmt.Errorf("%w: time_limit_sec must be a positive integer", service.ErrInvalidInput)
+	}
+
+	now := time.Now()
+	poll := &models.Poll{
+		ID:           uuid.New(),
+		SessionID:    s.ID,
+		Question:     question,
+		AnswerMode:   answerMode,
+		TimeLimitSec: timeLimitSec,
+		Status:       "draft",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	// Assign IDs to options and sort by position
+	for i := range options {
+		options[i].ID = uuid.New()
+		options[i].PollID = poll.ID
+	}
+	sort.Slice(options, func(i, j int) bool {
+		return options[i].Position < options[j].Position
+	})
+	poll.Options = options
+
+	m.polls[poll.ID] = poll
+	m.bySession[s.ID] = append(m.bySession[s.ID], poll.ID)
+
+	return poll, nil
+}
+
+func (m *mockPollService) ListPolls(sessionCode string, isHost bool) ([]models.Poll, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionCode]
+	if !ok {
+		return nil, service.ErrSessionNotFound
+	}
+
+	ids := m.bySession[s.ID]
+	var result []models.Poll
+	for i := len(ids) - 1; i >= 0; i-- {
+		p := m.polls[ids[i]]
+		if !isHost && p.Status == "draft" {
+			continue
+		}
+		result = append(result, *p)
+	}
+	return result, nil
+}
+
+func (m *mockPollService) GetPoll(sessionCode string, pollID uuid.UUID) (*models.Poll, map[uuid.UUID]int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.sessions[sessionCode]
+	if !ok {
+		return nil, nil, service.ErrSessionNotFound
+	}
+
+	p, ok := m.polls[pollID]
+	if !ok {
+		return nil, nil, service.ErrPollNotFound
+	}
+
+	// Return zero vote counts
+	voteCounts := make(map[uuid.UUID]int64)
+	for _, o := range p.Options {
+		voteCounts[o.ID] = 0
+	}
+	return p, voteCounts, nil
+}
+
+func (m *mockPollService) UpdatePollStatus(sessionCode string, pollID, hostID uuid.UUID, newStatus string) (*models.Poll, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.sessions[sessionCode]
+	if !ok {
+		return nil, service.ErrSessionNotFound
+	}
+	if s.HostID == nil || *s.HostID != hostID {
+		return nil, service.ErrNotSessionHost
+	}
+
+	p, ok := m.polls[pollID]
+	if !ok {
+		return nil, service.ErrPollNotFound
+	}
+
+	// Validate transition
+	transitions := map[string]string{"draft": "active", "active": "closed"}
+	allowed, validFrom := transitions[p.Status]
+	if !validFrom || allowed != newStatus {
+		return nil, fmt.Errorf("%w: cannot transition from %s to %s", service.ErrInvalidTransition, p.Status, newStatus)
+	}
+
+	p.Status = newStatus
+	p.UpdatedAt = time.Now()
+	return p, nil
+}
+
+// --- helper to set up router with poll mock ---
+
+func setupRouterWithPolls(t *testing.T) (*mockPollService, http.Handler) {
+	t.Helper()
+	authSvc := newMockAuthService()
+	sessionSvc := newMockSessionService()
+	pollSvc := newMockPollService()
+	r := router.New(time.Now(), authSvc, sessionSvc, pollSvc, testSecret)
+	return pollSvc, r
+}
+
+// --- acceptance tests ---------------------------------------------------
+
+// Create poll with valid data → 201, returns poll with options
+func TestCreatePoll_Success(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("A1B2C3", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{
+		"question": "What is the time complexity of binary search?",
+		"answer_mode": "single",
+		"time_limit_sec": 30,
+		"options": [
+			{"label": "O(1)", "position": 0},
+			{"label": "O(log n)", "position": 1},
+			{"label": "O(n)", "position": 2},
+			{"label": "O(n log n)", "position": 3}
+		]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/A1B2C3/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	if resp["id"] == nil || resp["id"] == "" {
+		t.Error("expected non-empty id")
+	}
+	if resp["question"] != "What is the time complexity of binary search?" {
+		t.Errorf("expected question match, got %v", resp["question"])
+	}
+	if resp["answer_mode"] != "single" {
+		t.Errorf("expected answer_mode=single, got %v", resp["answer_mode"])
+	}
+	if resp["status"] != "draft" {
+		t.Errorf("expected status=draft, got %v", resp["status"])
+	}
+
+	opts, ok := resp["options"].([]interface{})
+	if !ok || len(opts) != 4 {
+		t.Fatalf("expected 4 options, got %v", resp["options"])
+	}
+}
+
+// Poll is created with status: "draft" by default
+func TestCreatePoll_DefaultDraftStatus(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("AABBCC", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{
+		"question": "Test?",
+		"answer_mode": "single",
+		"options": [
+			{"label": "A", "position": 0},
+			{"label": "B", "position": 1}
+		]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/AABBCC/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	if resp["status"] != "draft" {
+		t.Errorf("expected status=draft, got %v", resp["status"])
+	}
+}
+
+// Cannot create a poll with fewer than 2 options → 400
+func TestCreatePoll_TooFewOptions_Returns400(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("FEWOPT", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{
+		"question": "Test?",
+		"answer_mode": "single",
+		"options": [{"label": "Only one", "position": 0}]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/FEWOPT/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Cannot create a poll with more than 6 options → 400
+func TestCreatePoll_TooManyOptions_Returns400(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("MNYOPT", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{
+		"question": "Test?",
+		"answer_mode": "single",
+		"options": [
+			{"label": "A", "position": 0},
+			{"label": "B", "position": 1},
+			{"label": "C", "position": 2},
+			{"label": "D", "position": 3},
+			{"label": "E", "position": 4},
+			{"label": "F", "position": 5},
+			{"label": "G", "position": 6}
+		]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/MNYOPT/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// GET /v1/sessions/:code/polls as audience → returns only active and closed polls (NOT draft)
+func TestListPolls_AudienceSeesOnlyActiveAndClosed(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("LSTPOL", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	// Create 3 polls
+	for _, q := range []string{"Draft Poll", "Active Poll", "Closed Poll"} {
+		body := fmt.Sprintf(`{
+			"question": "%s",
+			"answer_mode": "single",
+			"options": [
+				{"label": "A", "position": 0},
+				{"label": "B", "position": 1}
+			]
+		}`, q)
+		req := httptest.NewRequest(http.MethodPost, "/v1/sessions/LSTPOL/polls", bytes.NewBufferString(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("create poll %q: expected 201, got %d", q, rec.Code)
+		}
+	}
+
+	// Activate second poll
+	pollSvc.mu.Lock()
+	var pollIDs []uuid.UUID
+	for _, s := range pollSvc.sessions {
+		pollIDs = pollSvc.bySession[s.ID]
+	}
+	pollSvc.mu.Unlock()
+
+	// Activate poll[1]
+	activateBody := `{"status": "active"}`
+	req := httptest.NewRequest(http.MethodPatch, "/v1/sessions/LSTPOL/polls/"+pollIDs[1].String(), bytes.NewBufferString(activateBody))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activate poll: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Close poll[2]: first activate, then close
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/LSTPOL/polls/"+pollIDs[2].String(), bytes.NewBufferString(activateBody))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("activate poll for close: expected 200, got %d", rec.Code)
+	}
+
+	closeBody := `{"status": "closed"}`
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/LSTPOL/polls/"+pollIDs[2].String(), bytes.NewBufferString(closeBody))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("close poll: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Now GET as audience (no auth) — should only see 2 polls (active + closed), NOT draft
+	req = httptest.NewRequest(http.MethodGet, "/v1/sessions/LSTPOL/polls", nil)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list polls: expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var polls []map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&polls)
+
+	if len(polls) != 2 {
+		t.Fatalf("expected 2 polls (active+closed), got %d", len(polls))
+	}
+
+	for _, p := range polls {
+		status := p["status"].(string)
+		if status == "draft" {
+			t.Errorf("audience should not see draft polls, got status=%s", status)
+		}
+	}
+}
+
+// PATCH to activate → status changes to active
+func TestUpdatePoll_Activate(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("ACTPOL", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	// Create poll
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/ACTPOL/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	// Activate
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/ACTPOL/polls/"+pollID, bytes.NewBufferString(`{"status":"active"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["status"] != "active" {
+		t.Errorf("expected status=active, got %v", resp["status"])
+	}
+}
+
+// PATCH to close → status changes to closed
+func TestUpdatePoll_Close(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("CLSPOL", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	// Create and activate
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/CLSPOL/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	// Activate first
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSPOL/polls/"+pollID, bytes.NewBufferString(`{"status":"active"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	// Close
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSPOL/polls/"+pollID, bytes.NewBufferString(`{"status":"closed"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if resp["status"] != "closed" {
+		t.Errorf("expected status=closed, got %v", resp["status"])
+	}
+}
+
+// Cannot transition from closed → active → 400
+func TestUpdatePoll_ClosedToActive_Returns400(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("CLSACT", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	// Create → activate → close
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/CLSACT/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	for _, status := range []string{"active", "closed"} {
+		req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSACT/polls/"+pollID, bytes.NewBufferString(fmt.Sprintf(`{"status":"%s"}`, status)))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec = httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+	}
+
+	// Try closed → active
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSACT/polls/"+pollID, bytes.NewBufferString(`{"status":"active"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Cannot transition from closed → draft → 400
+func TestUpdatePoll_ClosedToDraft_Returns400(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("CLSDRF", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/CLSDRF/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	// activate then close
+	for _, status := range []string{"active", "closed"} {
+		req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSDRF/polls/"+pollID, bytes.NewBufferString(fmt.Sprintf(`{"status":"%s"}`, status)))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		rec = httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+	}
+
+	// Try closed → draft
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/CLSDRF/polls/"+pollID, bytes.NewBufferString(`{"status":"draft"}`))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Options are returned in position order
+func TestCreatePoll_OptionsInPositionOrder(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("ORDOPT", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	// Send options in reverse order
+	body := `{
+		"question": "Order test?",
+		"answer_mode": "single",
+		"options": [
+			{"label": "Third", "position": 2},
+			{"label": "First", "position": 0},
+			{"label": "Second", "position": 1}
+		]
+	}`
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/ORDOPT/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	opts := resp["options"].([]interface{})
+	labels := make([]string, len(opts))
+	for i, o := range opts {
+		labels[i] = o.(map[string]interface{})["label"].(string)
+	}
+
+	expected := []string{"First", "Second", "Third"}
+	for i, label := range labels {
+		if label != expected[i] {
+			t.Errorf("option %d: expected %q, got %q", i, expected[i], label)
+		}
+	}
+}
+
+// Only the session host can create polls → other users get 403
+func TestCreatePoll_NonHost_Returns403(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("NOHOST", hostID, "active")
+
+	// Different user
+	otherID := uuid.New()
+	token := generateTestJWT(t, otherID.String(), "other@example.com", testSecret, 24*time.Hour)
+
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/NOHOST/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Only the session host can activate/close polls → other users get 403
+func TestUpdatePoll_NonHost_Returns403(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("NOHST2", hostID, "active")
+
+	hostToken := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	// Create as host
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/NOHST2/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+hostToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	// Try activate as different user
+	otherID := uuid.New()
+	otherToken := generateTestJWT(t, otherID.String(), "other@example.com", testSecret, 24*time.Hour)
+
+	req = httptest.NewRequest(http.MethodPatch, "/v1/sessions/NOHST2/polls/"+pollID, bytes.NewBufferString(`{"status":"active"}`))
+	req.Header.Set("Authorization", "Bearer "+otherToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Creating a poll for a non-existent session → 404
+func TestCreatePoll_NonExistentSession_Returns404(t *testing.T) {
+	_, r := setupRouterWithPolls(t)
+
+	token := generateTestJWT(t, uuid.New().String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/NOEXST/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Creating a poll for an archived session → 400
+func TestCreatePoll_ArchivedSession_Returns400(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("ARCHVD", hostID, "archived")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/ARCHVD/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// GET poll details with vote counts per option
+func TestGetPoll_WithVoteCounts(t *testing.T) {
+	pollSvc, r := setupRouterWithPolls(t)
+	hostID := uuid.New()
+	pollSvc.addSession("GETPOL", hostID, "active")
+
+	token := generateTestJWT(t, hostID.String(), "host@example.com", testSecret, 24*time.Hour)
+
+	body := `{"question":"Q?","answer_mode":"single","options":[{"label":"A","position":0},{"label":"B","position":1}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/sessions/GETPOL/polls", bytes.NewBufferString(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	var created map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&created)
+	pollID := created["id"].(string)
+
+	// GET poll details (public, no auth)
+	req = httptest.NewRequest(http.MethodGet, "/v1/sessions/GETPOL/polls/"+pollID, nil)
+	rec = httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.NewDecoder(rec.Body).Decode(&resp)
+
+	opts := resp["options"].([]interface{})
+	for _, o := range opts {
+		opt := o.(map[string]interface{})
+		if _, ok := opt["vote_count"]; !ok {
+			t.Error("expected vote_count in option response")
+		}
+	}
+}
+
+// Suppress unused import warnings
+var _ = errors.New
+var _ = sort.Slice

--- a/apps/api/internal/handler/session_test.go
+++ b/apps/api/internal/handler/session_test.go
@@ -415,6 +415,6 @@ func setupRouterWithSession(t *testing.T) (*mockAuthService, *mockSessionService
 	t.Helper()
 	authSvc := newMockAuthService()
 	sessionSvc := newMockSessionService()
-	r := router.New(time.Now(), authSvc, sessionSvc, testSecret)
+	r := router.New(time.Now(), authSvc, sessionSvc, nil, testSecret)
 	return authSvc, sessionSvc, r
 }

--- a/apps/api/internal/middleware/jwt.go
+++ b/apps/api/internal/middleware/jwt.go
@@ -83,6 +83,56 @@ func JWTAuth(secret string) func(http.Handler) http.Handler {
 	}
 }
 
+// OptionalJWTAuth is like JWTAuth but does not reject requests without a token.
+// If a valid Bearer token is present, user_id and user_email are injected into
+// the context. Otherwise the request proceeds without them.
+func OptionalJWTAuth(secret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			token, err := jwt.Parse(parts[1], func(t *jwt.Token) (interface{}, error) {
+				if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, jwt.ErrSignatureInvalid
+				}
+				return []byte(secret), nil
+			})
+
+			if err != nil || !token.Valid {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			userID, _ := claims["user_id"].(string)
+			email, _ := claims["email"].(string)
+
+			if userID != "" && email != "" {
+				ctx := context.WithValue(r.Context(), ContextKeyUserID, userID)
+				ctx = context.WithValue(ctx, ContextKeyUserEmail, email)
+				r = r.WithContext(ctx)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // UserIDFromContext extracts the user_id from the request context.
 func UserIDFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(ContextKeyUserID).(string)

--- a/apps/api/internal/router/router.go
+++ b/apps/api/internal/router/router.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Eahtasham/live-pulse/apps/api/internal/middleware"
 )
 
-func New(startTime time.Time, authSvc handler.AuthService, sessionSvc handler.SessionServiceInterface, jwtSecret string) *chi.Mux {
+func New(startTime time.Time, authSvc handler.AuthService, sessionSvc handler.SessionServiceInterface, pollSvc handler.PollServiceInterface, jwtSecret string) *chi.Mux {
 	r := chi.NewRouter()
 
 	// Global middleware
@@ -42,6 +42,24 @@ func New(startTime time.Time, authSvc handler.AuthService, sessionSvc handler.Se
 		r.Post("/auth/login", authHandler.Login)
 		r.Get("/sessions/{code}", sessionHandler.GetByCode)
 		r.Post("/sessions/{code}/join", sessionHandler.Join)
+
+		// Poll public routes (optional auth to detect host)
+		if pollSvc != nil {
+			pollHandler := handler.NewPollHandler(pollSvc)
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.OptionalJWTAuth(jwtSecret))
+				r.Get("/sessions/{code}/polls", pollHandler.List)
+				r.Get("/sessions/{code}/polls/{pollID}", pollHandler.Get)
+			})
+
+			// Protected poll routes
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.JWTAuth(jwtSecret))
+				r.Post("/sessions/{code}/polls", pollHandler.Create)
+				r.Patch("/sessions/{code}/polls/{pollID}", pollHandler.Update)
+			})
+		}
+
 		// TODO: vote endpoints, Q&A submission endpoints (public)
 
 		// Protected routes — JWT required

--- a/apps/api/internal/service/poll.go
+++ b/apps/api/internal/service/poll.go
@@ -1,0 +1,236 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/Eahtasham/live-pulse/apps/api/internal/models"
+)
+
+var (
+	ErrSessionNotFound   = errors.New("session not found")
+	ErrSessionArchived   = errors.New("session is archived")
+	ErrNotSessionHost    = errors.New("not the session host")
+	ErrPollNotFound      = errors.New("poll not found")
+	ErrInvalidTransition = errors.New("invalid status transition")
+	ErrInvalidInput      = errors.New("invalid input")
+)
+
+type PollService struct {
+	db *gorm.DB
+}
+
+func NewPollService(db *gorm.DB) *PollService {
+	return &PollService{db: db}
+}
+
+// CreatePoll creates a new poll with options within a session.
+func (s *PollService) CreatePoll(sessionCode string, hostID uuid.UUID, question, answerMode string, timeLimitSec *int, options []models.PollOption) (*models.Poll, error) {
+	// Look up session
+	var session models.Session
+	if err := s.db.Where("code = ?", sessionCode).First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("find session: %w", err)
+	}
+
+	// Check archived
+	if session.Status == "archived" {
+		return nil, ErrSessionArchived
+	}
+
+	// Check host
+	if session.HostID == nil || *session.HostID != hostID {
+		return nil, ErrNotSessionHost
+	}
+
+	// Validate question
+	if question == "" || len(question) > 500 {
+		return nil, fmt.Errorf("%w: question is required and must be at most 500 characters", ErrInvalidInput)
+	}
+
+	// Validate answer_mode
+	if answerMode != "single" && answerMode != "multi" {
+		return nil, fmt.Errorf("%w: answer_mode must be 'single' or 'multi'", ErrInvalidInput)
+	}
+
+	// Validate options count
+	if len(options) < 2 || len(options) > 6 {
+		return nil, fmt.Errorf("%w: options must be between 2 and 6", ErrInvalidInput)
+	}
+
+	// Validate each option label
+	for _, o := range options {
+		if o.Label == "" || len(o.Label) > 200 {
+			return nil, fmt.Errorf("%w: option label is required and must be at most 200 characters", ErrInvalidInput)
+		}
+	}
+
+	// Validate time_limit_sec
+	if timeLimitSec != nil && *timeLimitSec <= 0 {
+		return nil, fmt.Errorf("%w: time_limit_sec must be a positive integer", ErrInvalidInput)
+	}
+
+	poll := models.Poll{
+		SessionID:    session.ID,
+		Question:     question,
+		AnswerMode:   answerMode,
+		TimeLimitSec: timeLimitSec,
+		Status:       "draft",
+		Options:      options,
+	}
+
+	if err := s.db.Create(&poll).Error; err != nil {
+		return nil, fmt.Errorf("create poll: %w", err)
+	}
+
+	// Reload with options sorted by position
+	if err := s.db.Preload("Options", func(db *gorm.DB) *gorm.DB {
+		return db.Order("position ASC")
+	}).First(&poll, "id = ?", poll.ID).Error; err != nil {
+		return nil, fmt.Errorf("reload poll: %w", err)
+	}
+
+	return &poll, nil
+}
+
+// ListPolls returns polls for a session. If isHost is false, only active and closed polls are returned.
+func (s *PollService) ListPolls(sessionCode string, isHost bool) ([]models.Poll, error) {
+	var session models.Session
+	if err := s.db.Where("code = ?", sessionCode).First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("find session: %w", err)
+	}
+
+	query := s.db.Where("session_id = ?", session.ID).Preload("Options", func(db *gorm.DB) *gorm.DB {
+		return db.Order("position ASC")
+	})
+
+	if !isHost {
+		query = query.Where("status IN ?", []string{"active", "closed"})
+	}
+
+	var polls []models.Poll
+	if err := query.Order("created_at DESC").Find(&polls).Error; err != nil {
+		return nil, fmt.Errorf("list polls: %w", err)
+	}
+
+	return polls, nil
+}
+
+// GetPoll returns a single poll with vote counts per option.
+func (s *PollService) GetPoll(sessionCode string, pollID uuid.UUID) (*models.Poll, map[uuid.UUID]int64, error) {
+	var session models.Session
+	if err := s.db.Where("code = ?", sessionCode).First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, ErrSessionNotFound
+		}
+		return nil, nil, fmt.Errorf("find session: %w", err)
+	}
+
+	var poll models.Poll
+	if err := s.db.Preload("Options", func(db *gorm.DB) *gorm.DB {
+		return db.Order("position ASC")
+	}).Where("id = ? AND session_id = ?", pollID, session.ID).First(&poll).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, ErrPollNotFound
+		}
+		return nil, nil, fmt.Errorf("find poll: %w", err)
+	}
+
+	// Get vote counts per option
+	type voteCount struct {
+		OptionID uuid.UUID `gorm:"column:option_id"`
+		Count    int64     `gorm:"column:count"`
+	}
+	var counts []voteCount
+	s.db.Model(&models.Vote{}).
+		Select("option_id, COUNT(*) as count").
+		Where("poll_id = ?", pollID).
+		Group("option_id").
+		Find(&counts)
+
+	voteCounts := make(map[uuid.UUID]int64)
+	for _, c := range counts {
+		voteCounts[c.OptionID] = c.Count
+	}
+
+	return &poll, voteCounts, nil
+}
+
+// UpdatePollStatus transitions a poll's status. Only forward transitions allowed.
+func (s *PollService) UpdatePollStatus(sessionCode string, pollID, hostID uuid.UUID, newStatus string) (*models.Poll, error) {
+	var session models.Session
+	if err := s.db.Where("code = ?", sessionCode).First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("find session: %w", err)
+	}
+
+	if session.HostID == nil || *session.HostID != hostID {
+		return nil, ErrNotSessionHost
+	}
+
+	var poll models.Poll
+	if err := s.db.Where("id = ? AND session_id = ?", pollID, session.ID).First(&poll).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrPollNotFound
+		}
+		return nil, fmt.Errorf("find poll: %w", err)
+	}
+
+	// Validate transition
+	if !isValidTransition(poll.Status, newStatus) {
+		return nil, fmt.Errorf("%w: cannot transition from %s to %s", ErrInvalidTransition, poll.Status, newStatus)
+	}
+
+	poll.Status = newStatus
+	if err := s.db.Save(&poll).Error; err != nil {
+		return nil, fmt.Errorf("update poll: %w", err)
+	}
+
+	// Reload with options
+	if err := s.db.Preload("Options", func(db *gorm.DB) *gorm.DB {
+		return db.Order("position ASC")
+	}).First(&poll, "id = ?", poll.ID).Error; err != nil {
+		return nil, fmt.Errorf("reload poll: %w", err)
+	}
+
+	return &poll, nil
+}
+
+// GetSessionByCode returns the session for host ownership checks in the handler layer.
+func (s *PollService) GetSessionByCode(code string) (*models.Session, error) {
+	var session models.Session
+	if err := s.db.Where("code = ?", code).First(&session).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("find session: %w", err)
+	}
+	return &session, nil
+}
+
+func isValidTransition(from, to string) bool {
+	transitions := map[string]string{
+		"draft":  "active",
+		"active": "closed",
+	}
+	allowed, ok := transitions[from]
+	return ok && allowed == to
+}
+
+// SortOptionsByPosition sorts options in-place by position.
+func SortOptionsByPosition(options []models.PollOption) {
+	sort.Slice(options, func(i, j int) bool {
+		return options[i].Position < options[j].Position
+	})
+}

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -43,7 +43,8 @@ func main() {
 	startTime := time.Now()
 	svc := service.New(gormDB, cfg.JWTSecret, cfg.JWTExpiry)
 	sessionSvc := service.NewSessionService(gormDB, rdb)
-	r := router.New(startTime, svc, sessionSvc, cfg.JWTSecret)
+	pollSvc := service.NewPollService(gormDB)
+	r := router.New(startTime, svc, sessionSvc, pollSvc, cfg.JWTSecret)
 
 	srv := &http.Server{
 		Addr:         ":" + cfg.APIPort,

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signIn } from "next-auth/react";
+import { isTemp } from "tempmail-checker";
 import { useState } from "react";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
@@ -17,6 +18,12 @@ export default function LoginPage() {
     e.preventDefault();
     setLoading(true);
     setError("");
+
+    if (isTemp(email)) {
+      setError("Disposable email addresses are not allowed");
+      setLoading(false);
+      return;
+    }
 
     if (mode === "register") {
       // Register via Go API, then sign in via NextAuth

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, useCallback } from "react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { CreateSessionDialog } from "@/components/session/create-session-dialog";
 import { SessionCard } from "@/components/session/session-card";
-import type { Session } from "@/lib/api";
+import type { Session } from "@/lib/session";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,65 +1,78 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 export default function Home() {
+  const [code, setCode] = useState("");
+  const router = useRouter();
+
+  function handleJoin(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = code.trim().toUpperCase();
+    if (trimmed.length === 6) {
+      router.push(`/session/${trimmed}`);
+    }
+  }
+
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-4">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
+
+      <div className="flex w-full max-w-md flex-col items-center gap-8">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold tracking-tight">LivePulse</h1>
+          <p className="mt-2 text-lg text-muted-foreground">
+            Real-time audience engagement
           </p>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
+
+        <form onSubmit={handleJoin} className="flex w-full gap-2">
+          <input
+            type="text"
+            value={code}
+            onChange={(e) => setCode(e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 6))}
+            placeholder="Enter session code"
+            maxLength={6}
+            className="flex-1 rounded-lg border border-input bg-background px-4 py-3 text-center font-mono text-lg font-semibold tracking-widest placeholder:font-sans placeholder:text-sm placeholder:font-normal placeholder:tracking-normal focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/50"
+          />
+          <button
+            type="submit"
+            disabled={code.trim().length !== 6}
+            className="rounded-lg bg-primary px-6 py-3 font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
           >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
+            Join
+          </button>
+        </form>
+
+        <div className="relative w-full">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-background px-2 text-muted-foreground">or</span>
+          </div>
         </div>
-      </main>
+
+        <div className="flex gap-3">
+          <Link
+            href="/login"
+            className="rounded-lg border border-border px-6 py-2.5 text-sm font-medium transition-colors hover:bg-muted"
+          >
+            Sign in
+          </Link>
+          <Link
+            href="/dashboard"
+            className="rounded-lg bg-secondary px-6 py-2.5 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+          >
+            Host Dashboard
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/session/[code]/page.tsx
+++ b/apps/web/app/session/[code]/page.tsx
@@ -1,10 +1,10 @@
 import { SessionJoinView } from "@/components/session/session-join-view";
 
-export default async function SessionPage({
-  params,
-}: {
+interface PageProps {
   params: Promise<{ code: string }>;
-}) {
+}
+
+export default async function SessionPage({ params }: PageProps) {
   const { code } = await params;
 
   return <SessionJoinView code={code} />;

--- a/apps/web/components/poll/create-poll-form.tsx
+++ b/apps/web/components/poll/create-poll-form.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface Props {
+  sessionCode: string;
+  token?: string;
+  onCreated: () => void;
+  onCancel: () => void;
+}
+
+interface OptionInput {
+  label: string;
+  position: number;
+}
+
+export function CreatePollForm({
+  sessionCode,
+  token,
+  onCreated,
+  onCancel,
+}: Props) {
+  const [question, setQuestion] = useState("");
+  const [answerMode, setAnswerMode] = useState<"single" | "multi">("single");
+  const [timeLimitSec, setTimeLimitSec] = useState("");
+  const [options, setOptions] = useState<OptionInput[]>([
+    { label: "", position: 0 },
+    { label: "", position: 1 },
+  ]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  function addOption() {
+    if (options.length >= 6) return;
+    setOptions([...options, { label: "", position: options.length }]);
+  }
+
+  function removeOption(index: number) {
+    if (options.length <= 2) return;
+    const updated = options
+      .filter((_, i) => i !== index)
+      .map((o, i) => ({ ...o, position: i }));
+    setOptions(updated);
+  }
+
+  function updateOptionLabel(index: number, label: string) {
+    const updated = [...options];
+    updated[index] = { ...updated[index], label };
+    setOptions(updated);
+  }
+
+  const canSubmit =
+    question.trim().length > 0 &&
+    options.length >= 2 &&
+    options.every((o) => o.label.trim().length > 0) &&
+    !loading;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setLoading(true);
+    setError("");
+
+    try {
+      const body: Record<string, unknown> = {
+        question: question.trim(),
+        answer_mode: answerMode,
+        options: options.map((o) => ({
+          label: o.label.trim(),
+          position: o.position,
+        })),
+      };
+
+      const tl = parseInt(timeLimitSec, 10);
+      if (!isNaN(tl) && tl > 0) {
+        body.time_limit_sec = tl;
+      }
+
+      const res = await fetch(
+        `${apiUrl}/v1/sessions/${encodeURIComponent(sessionCode)}/polls`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setError(data.message || "Failed to create poll");
+        return;
+      }
+
+      onCreated();
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+          {error}
+        </p>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor="poll-question">Question</Label>
+        <Input
+          id="poll-question"
+          placeholder="Enter your question..."
+          value={question}
+          onChange={(e) => setQuestion(e.target.value.slice(0, 500))}
+          required
+          autoFocus
+        />
+        <p className="text-xs text-muted-foreground">
+          {question.length}/500 characters
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Options</Label>
+        {options.map((option, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <Input
+              placeholder={`Option ${index + 1}`}
+              value={option.label}
+              onChange={(e) =>
+                updateOptionLabel(index, e.target.value.slice(0, 200))
+              }
+              required
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => removeOption(index)}
+              disabled={options.length <= 2}
+              aria-label="Remove option"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </Button>
+          </div>
+        ))}
+        {options.length < 6 && (
+          <Button type="button" variant="outline" size="sm" onClick={addOption}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M5 12h14" />
+              <path d="M12 5v14" />
+            </svg>
+            Add Option
+          </Button>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label>Answer Mode</Label>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setAnswerMode("single")}
+            className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+              answerMode === "single"
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            Single answer
+          </button>
+          <button
+            type="button"
+            onClick={() => setAnswerMode("multi")}
+            className={`flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+              answerMode === "multi"
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            Multi-select
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="time-limit">Time limit (seconds, optional)</Label>
+        <Input
+          id="time-limit"
+          type="number"
+          min="1"
+          placeholder="No limit"
+          value={timeLimitSec}
+          onChange={(e) => setTimeLimitSec(e.target.value)}
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={!canSubmit}>
+          {loading ? "Creating..." : "Create Poll"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/components/poll/poll-card.tsx
+++ b/apps/web/components/poll/poll-card.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { VoteButtons } from "@/components/poll/vote-buttons";
+import { ResultsChart } from "@/components/poll/results-chart";
+import { PollTimerBadge } from "@/components/poll/poll-timer-badge";
+import type { Poll } from "@/lib/poll";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface Props {
+  poll: Poll;
+  isHost: boolean;
+  sessionCode: string;
+  token?: string;
+  audienceUid: string;
+  onStatusChanged: () => void;
+}
+
+const statusColors: Record<string, "default" | "secondary" | "outline"> = {
+  draft: "outline",
+  active: "default",
+  closed: "secondary",
+};
+
+export function PollCard({
+  poll,
+  isHost,
+  sessionCode,
+  token,
+  audienceUid,
+  onStatusChanged,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [hasVoted, setHasVoted] = useState(false);
+  const [votedOptionIds, setVotedOptionIds] = useState<string[]>([]);
+  const [confirmClose, setConfirmClose] = useState(false);
+
+  async function updateStatus(newStatus: string) {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `${apiUrl}/v1/sessions/${encodeURIComponent(sessionCode)}/polls/${poll.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ status: newStatus }),
+        }
+      );
+
+      if (res.ok) {
+        onStatusChanged();
+      }
+    } finally {
+      setLoading(false);
+      setConfirmClose(false);
+    }
+  }
+
+  function handleVoted(selectedIds: string[]) {
+    setHasVoted(true);
+    setVotedOptionIds(selectedIds);
+    onStatusChanged(); // refresh to get updated vote counts
+  }
+
+  const showResults =
+    poll.status === "closed" || (poll.status === "active" && hasVoted) || isHost;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div className="space-y-1 min-w-0">
+          <CardTitle className="text-base leading-snug">
+            {poll.question}
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <Badge variant={statusColors[poll.status] ?? "outline"}>
+              {poll.status}
+            </Badge>
+            <span className="text-xs text-muted-foreground">
+              {poll.answer_mode === "single"
+                ? "Single answer"
+                : "Multi-select"}
+            </span>
+            {poll.time_limit_sec && poll.status === "active" && (
+              <PollTimerBadge
+                timeLimitSec={poll.time_limit_sec}
+                isActive={poll.status === "active"}
+              />
+            )}
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {/* Host controls */}
+        {isHost && (
+          <div className="flex gap-2">
+            {poll.status === "draft" && (
+              <Button
+                size="sm"
+                onClick={() => updateStatus("active")}
+                disabled={loading}
+              >
+                {loading ? "Activating..." : "Activate"}
+              </Button>
+            )}
+            {poll.status === "active" && !confirmClose && (
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setConfirmClose(true)}
+                disabled={loading}
+              >
+                Close Poll
+              </Button>
+            )}
+            {poll.status === "active" && confirmClose && (
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground">
+                  Close this poll?
+                </span>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => updateStatus("closed")}
+                  disabled={loading}
+                >
+                  {loading ? "Closing..." : "Confirm"}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setConfirmClose(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Audience voting (active poll, not yet voted) */}
+        {!isHost && poll.status === "active" && !hasVoted && (
+          <VoteButtons
+            pollId={poll.id}
+            sessionCode={sessionCode}
+            options={poll.options}
+            answerMode={poll.answer_mode}
+            audienceUid={audienceUid}
+            onVoted={handleVoted}
+          />
+        )}
+
+        {/* Post-vote confirmation */}
+        {!isHost && hasVoted && poll.status === "active" && (
+          <div className="rounded-lg bg-primary/10 px-4 py-3">
+            <p className="text-sm font-medium text-primary">
+              You&apos;ve voted!
+            </p>
+          </div>
+        )}
+
+        {/* Results chart */}
+        {showResults && (
+          <ResultsChart
+            options={poll.options}
+            highlightedIds={votedOptionIds}
+          />
+        )}
+
+        {/* Already voted indicator for audience on closed polls */}
+        {!isHost && poll.status === "closed" && !hasVoted && (
+          <ResultsChart options={poll.options} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/poll/poll-list.tsx
+++ b/apps/web/components/poll/poll-list.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CreatePollForm } from "@/components/poll/create-poll-form";
+import { PollCard } from "@/components/poll/poll-card";
+import type { Poll } from "@/lib/poll";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface Props {
+  sessionCode: string;
+  isHost: boolean;
+  token?: string;
+  audienceUid: string;
+}
+
+export function PollList({ sessionCode, isHost, token, audienceUid }: Props) {
+  const [polls, setPolls] = useState<Poll[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  const fetchPolls = useCallback(async () => {
+    try {
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) {
+        headers.Authorization = `Bearer ${token}`;
+      }
+
+      const res = await fetch(
+        `${apiUrl}/v1/sessions/${encodeURIComponent(sessionCode)}/polls`,
+        { headers }
+      );
+
+      if (res.ok) {
+        const data = await res.json();
+        setPolls(data ?? []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionCode, token]);
+
+  useEffect(() => {
+    fetchPolls();
+  }, [fetchPolls]);
+
+  function handlePollCreated() {
+    setShowCreateForm(false);
+    fetchPolls();
+  }
+
+  if (loading) {
+    return (
+      <p className="text-sm text-muted-foreground">Loading polls...</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Host: Create poll button + form */}
+      {isHost && (
+        <>
+          {showCreateForm ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Create Poll</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CreatePollForm
+                  sessionCode={sessionCode}
+                  token={token}
+                  onCreated={handlePollCreated}
+                  onCancel={() => setShowCreateForm(false)}
+                />
+              </CardContent>
+            </Card>
+          ) : (
+            <Button onClick={() => setShowCreateForm(true)}>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M5 12h14" />
+                <path d="M12 5v14" />
+              </svg>
+              Create Poll
+            </Button>
+          )}
+        </>
+      )}
+
+      {/* Polls list */}
+      {polls.length === 0 ? (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              {isHost
+                ? "No polls yet. Create one to get started!"
+                : "No active polls at the moment."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        polls.map((poll) => (
+          <PollCard
+            key={poll.id}
+            poll={poll}
+            isHost={isHost}
+            sessionCode={sessionCode}
+            token={token}
+            audienceUid={audienceUid}
+            onStatusChanged={fetchPolls}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/poll/poll-timer-badge.tsx
+++ b/apps/web/components/poll/poll-timer-badge.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { Badge } from "@/components/ui/badge";
+
+interface Props {
+  timeLimitSec: number;
+  isActive: boolean;
+}
+
+export function PollTimerBadge({ timeLimitSec, isActive }: Props) {
+  const [remaining, setRemaining] = useState(timeLimitSec);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    setRemaining(timeLimitSec);
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [timeLimitSec, isActive]);
+
+  if (!isActive || remaining <= 0) return null;
+
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  const timeStr = minutes > 0 ? `${minutes}:${seconds.toString().padStart(2, "0")}` : `${seconds}s`;
+
+  return (
+    <Badge
+      variant={remaining <= 10 ? "destructive" : "outline"}
+      className="font-mono"
+    >
+      {timeStr}
+    </Badge>
+  );
+}

--- a/apps/web/components/poll/results-chart.tsx
+++ b/apps/web/components/poll/results-chart.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import type { PollOption } from "@/lib/poll";
+
+interface Props {
+  options: PollOption[];
+  highlightedIds?: string[];
+}
+
+export function ResultsChart({ options, highlightedIds }: Props) {
+  const totalVotes = options.reduce((sum, o) => sum + o.vote_count, 0);
+  const maxVotes = Math.max(...options.map((o) => o.vote_count), 1);
+
+  return (
+    <div className="space-y-2">
+      {options.map((option) => {
+        const percentage =
+          totalVotes > 0 ? (option.vote_count / totalVotes) * 100 : 0;
+        const barWidth =
+          maxVotes > 0 ? (option.vote_count / maxVotes) * 100 : 0;
+        const isHighest =
+          totalVotes > 0 && option.vote_count === maxVotes;
+        const isHighlighted = highlightedIds?.includes(option.id);
+
+        return (
+          <div key={option.id} className="space-y-1">
+            <div className="flex items-center justify-between text-sm">
+              <span
+                className={`font-medium ${
+                  isHighlighted ? "text-primary" : ""
+                }`}
+              >
+                {option.label}
+                {isHighlighted && (
+                  <span className="ml-1 text-xs text-primary">✓</span>
+                )}
+              </span>
+              <span className="text-muted-foreground">
+                {option.vote_count} ({percentage.toFixed(0)}%)
+              </span>
+            </div>
+            <div className="h-6 w-full overflow-hidden rounded-md bg-muted">
+              <div
+                className={`h-full rounded-md transition-all duration-500 ${
+                  isHighest && totalVotes > 0
+                    ? "bg-primary"
+                    : "bg-primary/50"
+                }`}
+                style={{ width: `${barWidth}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+      <p className="text-xs text-muted-foreground">
+        {totalVotes} total vote{totalVotes !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/poll/vote-buttons.tsx
+++ b/apps/web/components/poll/vote-buttons.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { PollOption } from "@/lib/poll";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+interface Props {
+  pollId: string;
+  sessionCode: string;
+  options: PollOption[];
+  answerMode: "single" | "multi";
+  audienceUid: string;
+  onVoted: (selectedIds: string[]) => void;
+}
+
+export function VoteButtons({
+  pollId,
+  sessionCode,
+  options,
+  answerMode,
+  audienceUid,
+  onVoted,
+}: Props) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  function toggleOption(id: string) {
+    const next = new Set(selected);
+    if (answerMode === "single") {
+      next.clear();
+      next.add(id);
+    } else {
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+    }
+    setSelected(next);
+  }
+
+  async function handleVote() {
+    if (selected.size === 0) return;
+    setLoading(true);
+    setError("");
+
+    try {
+      // Submit votes for each selected option
+      for (const optionId of selected) {
+        const res = await fetch(
+          `${apiUrl}/v1/sessions/${encodeURIComponent(sessionCode)}/polls/${pollId}/vote`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              option_id: optionId,
+              audience_uid: audienceUid,
+            }),
+          }
+        );
+
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          if (data.message?.includes("already voted")) {
+            setError("You have already voted on this poll");
+            return;
+          }
+          setError(data.message || "Failed to vote");
+          return;
+        }
+      }
+
+      onVoted(Array.from(selected));
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {error && (
+        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+          {error}
+        </p>
+      )}
+      <div className="space-y-2">
+        {options.map((option) => {
+          const isSelected = selected.has(option.id);
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => toggleOption(option.id)}
+              className={`flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm font-medium transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border hover:bg-muted"
+              }`}
+            >
+              {/* Radio or checkbox indicator */}
+              <span
+                className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-${
+                  answerMode === "single" ? "full" : "md"
+                } border-2 ${
+                  isSelected
+                    ? "border-primary bg-primary"
+                    : "border-muted-foreground"
+                }`}
+              >
+                {isSelected && (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                )}
+              </span>
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+      <Button
+        onClick={handleVote}
+        disabled={selected.size === 0 || loading}
+        className="w-full"
+      >
+        {loading ? "Submitting..." : "Vote"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/components/session/create-session-dialog.tsx
+++ b/apps/web/components/session/create-session-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,11 +20,21 @@ interface Props {
   onCreated: () => void;
 }
 
+interface CreatedSession {
+  id: string;
+  code: string;
+  title: string;
+  status: string;
+}
+
 export function CreateSessionDialog({ token, onCreated }: Props) {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [title, setTitle] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [created, setCreated] = useState<CreatedSession | null>(null);
+  const [copied, setCopied] = useState(false);
 
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -46,8 +57,8 @@ export function CreateSessionDialog({ token, onCreated }: Props) {
         return;
       }
 
-      setTitle("");
-      setOpen(false);
+      const data = await res.json();
+      setCreated(data);
       onCreated();
     } catch {
       setError("Something went wrong");
@@ -56,8 +67,31 @@ export function CreateSessionDialog({ token, onCreated }: Props) {
     }
   }
 
+  function handleClose() {
+    setOpen(false);
+    setTitle("");
+    setCreated(null);
+    setCopied(false);
+    setError("");
+  }
+
+  function handleCopyLink() {
+    if (!created) return;
+    const link = `${window.location.origin}/session/${created.code}`;
+    navigator.clipboard.writeText(link).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) handleClose();
+        else setOpen(true);
+      }}
+    >
       <DialogTrigger asChild>
         <Button>
           <svg
@@ -79,38 +113,74 @@ export function CreateSessionDialog({ token, onCreated }: Props) {
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Create a new session</DialogTitle>
+          <DialogTitle>
+            {created ? "Session Created!" : "Create a new session"}
+          </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleCreate} className="space-y-4">
-          {error && (
-            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
-              {error}
-            </p>
-          )}
-          <div className="space-y-2">
-            <Label htmlFor="session-title">Session title</Label>
-            <Input
-              id="session-title"
-              placeholder="e.g. CS101 Lecture 5"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              required
-              autoFocus
-            />
+
+        {created ? (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-border bg-muted/50 p-4 text-center">
+              <p className="text-sm text-muted-foreground">Session Code</p>
+              <p className="mt-1 font-mono text-3xl font-bold tracking-widest">
+                {created.code}
+              </p>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <code className="flex-1 truncate rounded-md bg-muted px-3 py-2 text-sm">
+                {typeof window !== "undefined"
+                  ? `${window.location.origin}/session/${created.code}`
+                  : `/session/${created.code}`}
+              </code>
+              <Button variant="outline" size="sm" onClick={handleCopyLink}>
+                {copied ? "Copied!" : "Copy Link"}
+              </Button>
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={handleClose}>
+                Close
+              </Button>
+              <Button
+                onClick={() => router.push(`/session/${created.code}`)}
+              >
+                Go to Session
+              </Button>
+            </div>
           </div>
-          <div className="flex justify-end gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={loading || !title.trim()}>
-              {loading ? "Creating..." : "Create"}
-            </Button>
-          </div>
-        </form>
+        ) : (
+          <form onSubmit={handleCreate} className="space-y-4">
+            {error && (
+              <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+                {error}
+              </p>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="session-title">Session title</Label>
+              <Input
+                id="session-title"
+                placeholder="e.g. CS101 Lecture 5"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading || !title.trim()}>
+                {loading ? "Creating..." : "Create"}
+              </Button>
+            </div>
+          </form>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/components/session/session-card.tsx
+++ b/apps/web/components/session/session-card.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { Session } from "@/lib/api";
+import type { Session } from "@/lib/session";
 
 export function SessionCard({ session }: { session: Session }) {
   const [copied, setCopied] = useState(false);

--- a/apps/web/components/session/session-join-view.tsx
+++ b/apps/web/components/session/session-join-view.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PollList } from "@/components/poll/poll-list";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
@@ -15,19 +18,65 @@ function getClientId(): string {
   return id;
 }
 
+interface SessionData {
+  id: string;
+  code: string;
+  title: string;
+  status: string;
+  host_id?: string;
+}
+
 export function SessionJoinView({ code }: { code: string }) {
-  const [status, setStatus] = useState<"loading" | "joined" | "error">(
+  const { data: authSession } = useSession();
+  const [pageStatus, setPageStatus] = useState<"loading" | "joined" | "error">(
     "loading"
   );
-  const [sessionTitle, setSessionTitle] = useState("");
+  const [session, setSession] = useState<SessionData | null>(null);
   const [audienceUid, setAudienceUid] = useState("");
   const [error, setError] = useState("");
+  const [isHost, setIsHost] = useState(false);
+  const [activeTab, setActiveTab] = useState<"polls" | "qa">("polls");
+
+  const checkHost = useCallback(
+    (sessionData: SessionData) => {
+      if (authSession?.apiToken && sessionData.host_id) {
+        try {
+          const payload = JSON.parse(
+            atob(authSession.apiToken.split(".")[1])
+          );
+          if (payload.user_id === sessionData.host_id) {
+            setIsHost(true);
+          }
+        } catch {
+          // ignore decode errors
+        }
+      }
+    },
+    [authSession?.apiToken]
+  );
 
   useEffect(() => {
     async function join() {
       try {
+        // First get session details
+        const sessionRes = await fetch(
+          `${apiUrl}/v1/sessions/${encodeURIComponent(code)}`,
+          { headers: { "Content-Type": "application/json" } }
+        );
+
+        if (!sessionRes.ok) {
+          setError("Session not found");
+          setPageStatus("error");
+          return;
+        }
+
+        const sessionData: SessionData = await sessionRes.json();
+        setSession(sessionData);
+        checkHost(sessionData);
+
+        // Join the session
         const clientId = getClientId();
-        const res = await fetch(
+        const joinRes = await fetch(
           `${apiUrl}/v1/sessions/${encodeURIComponent(code)}/join`,
           {
             method: "POST",
@@ -38,26 +87,29 @@ export function SessionJoinView({ code }: { code: string }) {
           }
         );
 
-        if (!res.ok) {
+        if (!joinRes.ok) {
           setError("Session not found");
-          setStatus("error");
+          setPageStatus("error");
           return;
         }
 
-        const data = await res.json();
-        setSessionTitle(data.session_title);
-        setAudienceUid(data.audience_uid);
-        setStatus("joined");
+        const joinData = await joinRes.json();
+        setAudienceUid(joinData.audience_uid);
+        setPageStatus("joined");
       } catch {
         setError("Unable to connect");
-        setStatus("error");
+        setPageStatus("error");
       }
     }
 
     join();
-  }, [code]);
+  }, [code, checkHost]);
 
-  if (status === "loading") {
+  useEffect(() => {
+    if (session) checkHost(session);
+  }, [authSession, session, checkHost]);
+
+  if (pageStatus === "loading") {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <p className="text-muted-foreground">Joining session...</p>
@@ -65,12 +117,10 @@ export function SessionJoinView({ code }: { code: string }) {
     );
   }
 
-  if (status === "error") {
+  if (pageStatus === "error") {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center gap-4">
-        <h1 className="text-2xl font-bold text-destructive">
-          {error}
-        </h1>
+        <h1 className="text-2xl font-bold text-destructive">{error}</h1>
         <p className="text-muted-foreground">
           Check your session code and try again.
         </p>
@@ -79,32 +129,84 @@ export function SessionJoinView({ code }: { code: string }) {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">{sessionTitle}</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Session code:{" "}
-            <span className="font-mono font-semibold tracking-wider">
-              {code}
-            </span>
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-4 text-center">
-          <div className="rounded-lg bg-primary/10 px-4 py-3">
-            <p className="text-sm font-medium text-primary">
-              You&apos;ve joined the session!
-            </p>
+    <div className="min-h-screen bg-background">
+      {/* Session header */}
+      <div className="border-b border-border bg-card">
+        <div className="mx-auto flex max-w-4xl items-center justify-between px-4 py-4">
+          <div>
+            <h1 className="text-xl font-bold">{session?.title}</h1>
+            <div className="mt-1 flex items-center gap-2">
+              <span className="font-mono text-sm font-semibold tracking-wider text-muted-foreground">
+                {code}
+              </span>
+              <Badge
+                variant={
+                  session?.status === "active" ? "default" : "secondary"
+                }
+              >
+                {session?.status}
+              </Badge>
+              {isHost && <Badge variant="outline">Host</Badge>}
+            </div>
           </div>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Polls and Q&amp;A will appear here when the host starts them.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Your audience ID:{" "}
-            <code className="font-mono">{audienceUid.slice(0, 8)}…</code>
-          </p>
-        </CardContent>
-      </Card>
+          {!isHost && (
+            <p className="text-xs text-muted-foreground">
+              ID:{" "}
+              <code className="font-mono">{audienceUid.slice(0, 8)}…</code>
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="border-b border-border bg-card">
+        <div className="mx-auto flex max-w-4xl px-4">
+          <button
+            onClick={() => setActiveTab("polls")}
+            className={`border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
+              activeTab === "polls"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Polls
+          </button>
+          <button
+            onClick={() => setActiveTab("qa")}
+            className={`border-b-2 px-4 py-2.5 text-sm font-medium transition-colors ${
+              activeTab === "qa"
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Q&amp;A
+          </button>
+        </div>
+      </div>
+
+      {/* Tab content */}
+      <div className="mx-auto max-w-4xl px-4 py-6">
+        {activeTab === "polls" && (
+          <PollList
+            sessionCode={code}
+            isHost={isHost}
+            token={authSession?.apiToken}
+            audienceUid={audienceUid}
+          />
+        )}
+        {activeTab === "qa" && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Q&amp;A</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Q&amp;A will be available in a future update.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,9 +1,10 @@
 import { auth } from "@/auth"
 
-const API_URL = process.env.API_URL || "http://localhost:8080"
+export const API_URL = process.env.API_URL || "http://localhost:8080"
 
 /**
  * Fetch wrapper that attaches the Go API JWT from the current session.
+ * For use in server components / server actions only.
  */
 export async function apiFetch(
   path: string,
@@ -23,59 +24,3 @@ export async function apiFetch(
   })
 }
 
-// ── Session types ────────────────────────────────────────────────────
-
-export interface Session {
-  id: string
-  code: string
-  title: string
-  status: string
-  created_at: string
-  host_id?: string
-}
-
-export interface JoinResponse {
-  audience_uid: string
-  session_title: string
-}
-
-// ── Session API (server-side, uses auth) ─────────────────────────────
-
-export async function createSession(title: string): Promise<Session> {
-  const res = await apiFetch("/v1/sessions", {
-    method: "POST",
-    body: JSON.stringify({ title }),
-  })
-  if (!res.ok) throw new Error("Failed to create session")
-  return res.json()
-}
-
-export async function listSessions(): Promise<Session[]> {
-  const res = await apiFetch("/v1/sessions")
-  if (!res.ok) throw new Error("Failed to list sessions")
-  return res.json()
-}
-
-export async function getSessionByCode(code: string): Promise<Session> {
-  const res = await fetch(`${API_URL}/v1/sessions/${encodeURIComponent(code)}`, {
-    headers: { "Content-Type": "application/json" },
-    cache: "no-store",
-  })
-  if (!res.ok) throw new Error("Session not found")
-  return res.json()
-}
-
-export async function joinSession(
-  code: string,
-  clientId: string
-): Promise<JoinResponse> {
-  const res = await fetch(`${API_URL}/v1/sessions/${encodeURIComponent(code)}/join`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Client-ID": clientId,
-    },
-  })
-  if (!res.ok) throw new Error("Failed to join session")
-  return res.json()
-}

--- a/apps/web/lib/poll.ts
+++ b/apps/web/lib/poll.ts
@@ -1,0 +1,27 @@
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface PollOption {
+  id: string
+  label: string
+  position: number
+  vote_count: number
+}
+
+export interface Poll {
+  id: string
+  session_id: string
+  question: string
+  answer_mode: "single" | "multi"
+  status: "draft" | "active" | "closed"
+  time_limit_sec: number | null
+  options: PollOption[]
+  created_at: string
+  updated_at: string
+}
+
+export interface VoteResponse {
+  id: string
+  poll_id: string
+  option_id: string
+  audience_uid: string
+}

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -1,0 +1,66 @@
+import { apiFetch, API_URL } from "./api"
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface Session {
+  id: string
+  code: string
+  title: string
+  status: string
+  created_at: string
+  host_id?: string
+}
+
+export interface JoinResponse {
+  audience_uid: string
+  session_title: string
+}
+
+// ── Server-side API (uses auth via apiFetch) ─────────────────────────
+
+export async function createSession(title: string): Promise<Session> {
+  const res = await apiFetch("/v1/sessions", {
+    method: "POST",
+    body: JSON.stringify({ title }),
+  })
+  if (!res.ok) throw new Error("Failed to create session")
+  return res.json()
+}
+
+export async function listSessions(): Promise<Session[]> {
+  const res = await apiFetch("/v1/sessions")
+  if (!res.ok) throw new Error("Failed to list sessions")
+  return res.json()
+}
+
+// ── Public API (no auth needed) ──────────────────────────────────────
+
+export async function getSessionByCode(code: string): Promise<Session> {
+  const res = await fetch(
+    `${API_URL}/v1/sessions/${encodeURIComponent(code)}`,
+    {
+      headers: { "Content-Type": "application/json" },
+      cache: "no-store",
+    }
+  )
+  if (!res.ok) throw new Error("Session not found")
+  return res.json()
+}
+
+export async function joinSession(
+  code: string,
+  clientId: string
+): Promise<JoinResponse> {
+  const res = await fetch(
+    `${API_URL}/v1/sessions/${encodeURIComponent(code)}/join`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Client-ID": clientId,
+      },
+    }
+  )
+  if (!res.ok) throw new Error("Failed to join session")
+  return res.json()
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "react-dom": "19.2.4",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
+    "tempmail-checker": "^1.0.0",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tempmail-checker:
+        specifier: ^1.0.0
+        version: 1.0.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3521,6 +3524,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tempmail-checker@1.0.0:
+    resolution: {integrity: sha512-JjBxii5vGHWQY3Bv2NStoqlHam0a3pbZmfJSFed0D9xrEGzv1k4eUsfk9KYbsS/eZr9Z1SW8FF9J1NFD0TpMvQ==}
+    engines: {node: '>=18.0.0'}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -3528,8 +3535,15 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.28:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
@@ -7515,6 +7529,10 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tempmail-checker@1.0.0:
+    dependencies:
+      tldts: 6.1.86
+
   tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.15:
@@ -7522,7 +7540,13 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.28: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.28:
     dependencies:


### PR DESCRIPTION
- Closes #5 (Phase 4): Poll CRUD backend — service, handler, routes, tests
- Closes #12 (Phase 11): Auth UI and dashboard with session management
- Closes #13 (Phase 12): Session join view with host/audience detection
- Closes #14 (Phase 13): Poll UI — create form, vote buttons, results chart, timer

Also adds OptionalJWTAuth middleware for host detection on public poll routes, splits lib/api.ts into separate session and poll modules.