### PR TITLE
feat: add Redis Pub/Sub bridge between API and realtime services

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,243 @@
+# LivePulse — API Service
+
+The Go REST API powering LivePulse. Handles authentication, sessions, polls, votes, Q&A, and publishes real-time events to Redis Pub/Sub.
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│   Handlers   │────▶│   Services   │────▶│  PostgreSQL  │
+│  (chi router)│     │ (biz logic)  │     │   (GORM)     │
+└──────────────┘     └──────┬───────┘     └──────────────┘
+                            │
+                            ▼
+                     ┌──────────────┐     ┌──────────────┐
+                     │  Publisher   │────▶│    Redis     │
+                     │ (Pub/Sub)   │     │  (go-redis)  │
+                     └──────────────┘     └──────────────┘
+```
+
+## Directory Structure
+
+```
+apps/api/
+├── main.go                      # Entry point, wires dependencies
+├── docs/                        # Swagger auto-generated docs
+├── internal/
+│   ├── config/config.go         # Environment-based configuration
+│   ├── db/
+│   │   ├── postgres.go          # GORM PostgreSQL connection
+│   │   └── redis.go             # go-redis client factory
+│   ├── handler/                  # HTTP handlers (one file per domain)
+│   │   ├── auth.go
+│   │   ├── health.go
+│   │   ├── poll.go
+│   │   ├── qa.go
+│   │   ├── qavote.go
+│   │   ├── session.go
+│   │   └── vote.go
+│   ├── middleware/
+│   │   ├── jwt.go               # JWT auth middleware
+│   │   └── logger.go            # Structured request logging
+│   ├── models/                   # GORM models
+│   │   ├── poll.go              # Poll, PollOption, Vote
+│   │   ├── qa.go                # QAEntry, QAVote
+│   │   ├── session.go
+│   │   └── user.go
+│   ├── router/router.go         # Route definitions + middleware stack
+│   └── service/                  # Business logic layer
+│       ├── auth.go
+│       ├── poll.go
+│       ├── publisher.go         # ★ Redis Pub/Sub event publisher
+│       ├── qa.go
+│       ├── qavote.go
+│       ├── session.go
+│       └── vote.go
+```
+
+## Environment Variables
+
+| Variable       | Default                                                              | Description                 |
+| -------------- | -------------------------------------------------------------------- | --------------------------- |
+| `API_PORT`     | `8080`                                                               | HTTP listen port            |
+| `DATABASE_URL` | `postgres://livepulse:livepulse_dev@localhost:5432/livepulse?sslmode=disable` | PostgreSQL connection string |
+| `REDIS_URL`    | `redis://localhost:6379/0`                                           | Redis connection string     |
+| `JWT_SECRET`   | `dev-secret-change-me`                                               | JWT signing secret          |
+| `JWT_EXPIRY`   | `24h`                                                                | JWT token expiry duration   |
+
+## Running
+
+```bash
+# From repo root
+cd apps/api
+go run main.go
+
+# Or with Docker
+docker compose up api
+```
+
+Swagger UI available at `http://localhost:8080/swagger/index.html`.
+
+## API Endpoints
+
+### Auth
+| Method | Path                  | Auth | Description              |
+| ------ | --------------------- | ---- | ------------------------ |
+| POST   | `/v1/auth/register`   | No   | Register with email      |
+| POST   | `/v1/auth/login`      | No   | Login with email         |
+| POST   | `/v1/auth/callback`   | No   | OAuth callback           |
+
+### Sessions
+| Method | Path                       | Auth | Description              |
+| ------ | -------------------------- | ---- | ------------------------ |
+| POST   | `/v1/sessions`             | JWT  | Create session           |
+| GET    | `/v1/sessions`             | JWT  | List host's sessions     |
+| GET    | `/v1/sessions/{code}`      | No   | Get session by code      |
+| POST   | `/v1/sessions/{code}/join` | No   | Join as audience         |
+
+### Polls
+| Method | Path                                        | Auth     | Description         |
+| ------ | ------------------------------------------- | -------- | ------------------- |
+| POST   | `/v1/sessions/{code}/polls`                 | JWT      | Create poll         |
+| GET    | `/v1/sessions/{code}/polls`                 | Optional | List polls          |
+| GET    | `/v1/sessions/{code}/polls/{pollID}`        | Optional | Get poll            |
+| PATCH  | `/v1/sessions/{code}/polls/{pollID}`        | JWT      | Update poll status  |
+| POST   | `/v1/sessions/{code}/polls/{pollID}/vote`   | No*      | Cast vote           |
+
+### Q&A
+| Method | Path                                       | Auth | Description         |
+| ------ | ------------------------------------------ | ---- | ------------------- |
+| GET    | `/v1/sessions/{code}/qa`                   | No   | List Q&A entries    |
+| POST   | `/v1/sessions/{code}/qa`                   | No*  | Submit question     |
+| PATCH  | `/v1/sessions/{code}/qa/{id}`              | JWT  | Moderate entry      |
+| POST   | `/v1/sessions/{code}/qa/{id}/vote`         | No*  | Upvote/downvote     |
+
+*Requires `X-Audience-UID` header (obtained from `/join`).
+
+---
+
+## Redis Pub/Sub — Publisher
+
+The API service acts as the **publisher** in the Redis Pub/Sub architecture. After every successful database write that affects real-time state, the service publishes a JSON event to the Redis channel `session:{CODE}`.
+
+### How It Works
+
+1. A `Publisher` struct wraps the Redis client (`service/publisher.go`)
+2. It's injected into `VoteService`, `QAService`, and `QAVoteService` at startup
+3. After each successful DB transaction, the service publishes an event
+4. Publishing is **fire-and-forget** — failures are logged but don't fail the HTTP response
+
+### Channel Format
+
+```
+session:{SESSION_CODE}
+```
+
+Example: `session:A1B2C3`
+
+One channel per active session. The realtime service subscribes to these channels per-room.
+
+### Event Types & Payloads
+
+#### `vote_update` — Cast vote
+
+Published after a vote is inserted. Contains **ALL options with current total counts** (not deltas).
+
+```json
+{
+  "type": "vote_update",
+  "payload": {
+    "pollId": "189e5856-4773-419d-80f5-5515cab2731c",
+    "options": [
+      { "id": "uuid-1", "label": "Option A", "vote_count": 42 },
+      { "id": "uuid-2", "label": "Option B", "vote_count": 37 }
+    ]
+  }
+}
+```
+
+**Why full state?** The frontend receives the complete snapshot and re-renders the chart from scratch. This prevents state accumulation bugs where a missed delta message causes the UI to be permanently out of sync.
+
+#### `new_question` — Question submitted
+
+```json
+{
+  "type": "new_question",
+  "payload": {
+    "id": "uuid",
+    "entry_type": "question",
+    "body": "What's the roadmap for Q3?",
+    "score": 0,
+    "author_uid": "audience-uid",
+    "created_at": "2026-04-15T12:00:00Z"
+  }
+}
+```
+
+#### `new_comment` — Comment submitted
+
+```json
+{
+  "type": "new_comment",
+  "payload": {
+    "id": "uuid",
+    "entry_type": "comment",
+    "body": "Great presentation!",
+    "author_uid": "audience-uid",
+    "created_at": "2026-04-15T12:00:00Z"
+  }
+}
+```
+
+#### `qa_update` — Moderation or Q&A vote
+
+Published when host pins/hides/archives an entry OR when an audience member upvotes/downvotes.
+
+```json
+{
+  "type": "qa_update",
+  "payload": {
+    "id": "uuid",
+    "status": "pinned",
+    "is_hidden": false,
+    "score": 15
+  }
+}
+```
+
+#### `session_closed` — Session closed
+
+```json
+{
+  "type": "session_closed",
+  "payload": {
+    "code": "A1B2C3",
+    "closed_at": "2026-04-15T14:00:00Z"
+  }
+}
+```
+
+### Publish Trigger Points
+
+| Service          | Method          | Event Published     | Timing                        |
+| ---------------- | --------------- | ------------------- | ----------------------------- |
+| `VoteService`    | `CastVote`      | `vote_update`       | After vote insert (goroutine) |
+| `QAService`      | `CreateEntry`   | `new_question` / `new_comment` | After entry insert |
+| `QAService`      | `ModerateEntry` | `qa_update`         | After entry update            |
+| `QAVoteService`  | `CastVote`      | `qa_update`         | After each commit             |
+
+### Important Implementation Details
+
+- **`vote_update` runs in a goroutine** with `context.Background()` — not the HTTP request context, since the request context is canceled when the response is sent.
+- **All other publishes are synchronous** but non-blocking — Redis PUBLISH is fast (~1ms).
+- **Nil-safe**: If `Publisher` is nil (e.g., in tests), publish calls are skipped.
+
+### Verifying with redis-cli
+
+```bash
+# Monitor all Redis commands
+redis-cli MONITOR
+
+# Subscribe to a specific session channel
+redis-cli SUBSCRIBE session:A1B2C3
+```

--- a/apps/api/internal/service/publisher.go
+++ b/apps/api/internal/service/publisher.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+// Event represents a real-time event published to Redis.
+type Event struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload"`
+}
+
+// VoteUpdatePayload is sent when a vote is cast, containing ALL options with current counts.
+type VoteUpdatePayload struct {
+	PollID  string              `json:"pollId"`
+	Options []VoteOptionPayload `json:"options"`
+}
+
+type VoteOptionPayload struct {
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	VoteCount int64  `json:"vote_count"`
+}
+
+// NewQuestionPayload is sent when a new question is submitted.
+type NewQuestionPayload struct {
+	ID        string `json:"id"`
+	EntryType string `json:"entry_type"`
+	Body      string `json:"body"`
+	Score     int    `json:"score"`
+	AuthorUID string `json:"author_uid"`
+	CreatedAt string `json:"created_at"`
+}
+
+// NewCommentPayload is sent when a new comment is submitted.
+type NewCommentPayload struct {
+	ID        string `json:"id"`
+	EntryType string `json:"entry_type"`
+	Body      string `json:"body"`
+	AuthorUID string `json:"author_uid"`
+	CreatedAt string `json:"created_at"`
+}
+
+// QAUpdatePayload is sent on moderation actions or Q&A votes.
+type QAUpdatePayload struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"`
+	IsHidden bool   `json:"is_hidden"`
+	Score    int    `json:"score"`
+}
+
+// SessionClosedPayload is sent when a session is closed.
+type SessionClosedPayload struct {
+	Code     string `json:"code"`
+	ClosedAt string `json:"closed_at"`
+}
+
+// Publisher wraps Redis PUBLISH with typed event constructors.
+type Publisher struct {
+	rdb *redis.Client
+}
+
+// NewPublisher creates a new Publisher.
+func NewPublisher(rdb *redis.Client) *Publisher {
+	return &Publisher{rdb: rdb}
+}
+
+func (p *Publisher) publish(ctx context.Context, code string, event Event) {
+	data, err := json.Marshal(event)
+	if err != nil {
+		slog.Error("failed to marshal event", "type", event.Type, "error", err)
+		return
+	}
+
+	channel := "session:" + code
+	if err := p.rdb.Publish(ctx, channel, data).Err(); err != nil {
+		slog.Error("failed to publish event", "channel", channel, "type", event.Type, "error", err)
+	} else {
+		slog.Debug("published event", "channel", channel, "type", event.Type)
+	}
+}
+
+// PublishVoteUpdate publishes a vote_update event with full poll state.
+func (p *Publisher) PublishVoteUpdate(ctx context.Context, code string, pollID uuid.UUID, options []VoteOptionPayload) {
+	p.publish(ctx, code, Event{
+		Type: "vote_update",
+		Payload: VoteUpdatePayload{
+			PollID:  pollID.String(),
+			Options: options,
+		},
+	})
+}
+
+// PublishNewQuestion publishes a new_question event.
+func (p *Publisher) PublishNewQuestion(ctx context.Context, code string, id uuid.UUID, body, authorUID string, score int, createdAt time.Time) {
+	p.publish(ctx, code, Event{
+		Type: "new_question",
+		Payload: NewQuestionPayload{
+			ID:        id.String(),
+			EntryType: "question",
+			Body:      body,
+			Score:     score,
+			AuthorUID: authorUID,
+			CreatedAt: createdAt.Format(time.RFC3339),
+		},
+	})
+}
+
+// PublishNewComment publishes a new_comment event.
+func (p *Publisher) PublishNewComment(ctx context.Context, code string, id uuid.UUID, body, authorUID string, createdAt time.Time) {
+	p.publish(ctx, code, Event{
+		Type: "new_comment",
+		Payload: NewCommentPayload{
+			ID:        id.String(),
+			EntryType: "comment",
+			Body:      body,
+			AuthorUID: authorUID,
+			CreatedAt: createdAt.Format(time.RFC3339),
+		},
+	})
+}
+
+// PublishQAUpdate publishes a qa_update event.
+func (p *Publisher) PublishQAUpdate(ctx context.Context, code string, id uuid.UUID, status string, isHidden bool, score int) {
+	p.publish(ctx, code, Event{
+		Type: "qa_update",
+		Payload: QAUpdatePayload{
+			ID:       id.String(),
+			Status:   status,
+			IsHidden: isHidden,
+			Score:    score,
+		},
+	})
+}
+
+// PublishSessionClosed publishes a session_closed event.
+func (p *Publisher) PublishSessionClosed(ctx context.Context, code string, closedAt time.Time) {
+	p.publish(ctx, code, Event{
+		Type: "session_closed",
+		Payload: SessionClosedPayload{
+			Code:     code,
+			ClosedAt: closedAt.Format(time.RFC3339),
+		},
+	})
+}
+
+// BuildVoteOptionPayloads constructs VoteOptionPayload slice from poll options and vote counts.
+func BuildVoteOptionPayloads(pollID uuid.UUID, options []struct {
+	ID    uuid.UUID
+	Label string
+}, voteCounts map[uuid.UUID]int64) []VoteOptionPayload {
+	result := make([]VoteOptionPayload, len(options))
+	for i, opt := range options {
+		result[i] = VoteOptionPayload{
+			ID:        opt.ID.String(),
+			Label:     opt.Label,
+			VoteCount: voteCounts[opt.ID],
+		}
+	}
+	return result
+}
+
+// GetPollOptionsWithCounts fetches poll options and vote counts, returning VoteOptionPayloads.
+func (p *Publisher) GetPollOptionsWithCounts(ctx context.Context, pollID uuid.UUID, db interface {
+	GetPollWithOptions(pollID uuid.UUID) ([]struct {
+		ID    uuid.UUID
+		Label string
+	}, error)
+	GetVoteCounts(pollID uuid.UUID) (map[uuid.UUID]int64, error)
+}) ([]VoteOptionPayload, error) {
+	options, err := db.GetPollWithOptions(pollID)
+	if err != nil {
+		return nil, fmt.Errorf("get poll options: %w", err)
+	}
+
+	counts, err := db.GetVoteCounts(pollID)
+	if err != nil {
+		return nil, fmt.Errorf("get vote counts: %w", err)
+	}
+
+	return BuildVoteOptionPayloads(pollID, options, counts), nil
+}

--- a/apps/api/internal/service/qa.go
+++ b/apps/api/internal/service/qa.go
@@ -37,13 +37,15 @@ type QAEntryWithVote struct {
 type QAService struct {
 	db  *gorm.DB
 	rdb *redis.Client
+	pub *Publisher
 }
 
 // NewQAService creates a new QAService.
-func NewQAService(database *gorm.DB, redisClient *redis.Client) *QAService {
+func NewQAService(database *gorm.DB, redisClient *redis.Client, pub *Publisher) *QAService {
 	return &QAService{
 		db:  database,
 		rdb: redisClient,
+		pub: pub,
 	}
 }
 
@@ -92,6 +94,15 @@ func (s *QAService) CreateEntry(sessionCode, authorUID, entryType, body string) 
 
 	if err := s.db.Create(entry).Error; err != nil {
 		return nil, fmt.Errorf("create entry: %w", err)
+	}
+
+	// Publish event
+	if s.pub != nil {
+		if entryType == "question" {
+			s.pub.PublishNewQuestion(context.Background(), sessionCode, entry.ID, entry.Body, entry.AuthorUID, entry.Score, entry.CreatedAt)
+		} else {
+			s.pub.PublishNewComment(context.Background(), sessionCode, entry.ID, entry.Body, entry.AuthorUID, entry.CreatedAt)
+		}
 	}
 
 	return entry, nil
@@ -225,6 +236,11 @@ func (s *QAService) ModerateEntry(sessionCode string, entryID, hostID uuid.UUID,
 	// Save changes
 	if err := s.db.Save(&entry).Error; err != nil {
 		return nil, fmt.Errorf("update entry: %w", err)
+	}
+
+	// Publish qa_update event
+	if s.pub != nil {
+		s.pub.PublishQAUpdate(context.Background(), sessionCode, entry.ID, entry.Status, entry.IsHidden, entry.Score)
 	}
 
 	return &entry, nil

--- a/apps/api/internal/service/qavote.go
+++ b/apps/api/internal/service/qavote.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -13,9 +14,9 @@ import (
 )
 
 var (
-	ErrQAEntryIsComment    = errors.New("cannot vote on comments")
-	ErrQAEntryNotVisible   = errors.New("qa entry is not visible")
-	ErrInvalidVoteValue    = errors.New("vote value must be 1 (upvote) or -1 (downvote)")
+	ErrQAEntryIsComment  = errors.New("cannot vote on comments")
+	ErrQAEntryNotVisible = errors.New("qa entry is not visible")
+	ErrInvalidVoteValue  = errors.New("vote value must be 1 (upvote) or -1 (downvote)")
 )
 
 // QAVoteServiceInterface defines the interface for Q&A vote business logic.
@@ -28,13 +29,15 @@ type QAVoteServiceInterface interface {
 type QAVoteService struct {
 	db  *gorm.DB
 	rdb *redis.Client
+	pub *Publisher
 }
 
 // NewQAVoteService creates a new QAVoteService.
-func NewQAVoteService(database *gorm.DB, redisClient *redis.Client) *QAVoteService {
+func NewQAVoteService(database *gorm.DB, redisClient *redis.Client, pub *Publisher) *QAVoteService {
 	return &QAVoteService{
 		db:  database,
 		rdb: redisClient,
+		pub: pub,
 	}
 }
 
@@ -122,6 +125,7 @@ func (s *QAVoteService) CastVote(sessionCode string, entryID uuid.UUID, voterUID
 			if err := tx.Commit().Error; err != nil {
 				return nil, fmt.Errorf("commit transaction: %w", err)
 			}
+			s.publishQAUpdate(sessionCode, entryID, entry.Status, entry.IsHidden, entry.Score-int(value))
 			return nil, nil // Vote removed
 		} else {
 			// Different vote value - update the vote
@@ -140,6 +144,7 @@ func (s *QAVoteService) CastVote(sessionCode string, entryID uuid.UUID, voterUID
 			if err := tx.Commit().Error; err != nil {
 				return nil, fmt.Errorf("commit transaction: %w", err)
 			}
+			s.publishQAUpdate(sessionCode, entryID, entry.Status, entry.IsHidden, entry.Score+scoreChange)
 			return &existingVote, nil
 		}
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -170,7 +175,15 @@ func (s *QAVoteService) CastVote(sessionCode string, entryID uuid.UUID, voterUID
 		return nil, fmt.Errorf("commit transaction: %w", err)
 	}
 
+	s.publishQAUpdate(sessionCode, entryID, entry.Status, entry.IsHidden, entry.Score+int(value))
+
 	return vote, nil
+}
+
+func (s *QAVoteService) publishQAUpdate(sessionCode string, entryID uuid.UUID, status string, isHidden bool, score int) {
+	if s.pub != nil {
+		s.pub.PublishQAUpdate(context.Background(), sessionCode, entryID, status, isHidden, score)
+	}
 }
 
 // recalculateScore recalculates the score for a Q&A entry based on all votes.

--- a/apps/api/internal/service/vote.go
+++ b/apps/api/internal/service/vote.go
@@ -13,22 +13,23 @@ import (
 )
 
 var (
-	ErrPollNotActive       = errors.New("poll is not active")
-	ErrPollClosed          = errors.New("poll is closed")
-	ErrInvalidOption       = errors.New("invalid option for this poll")
-	ErrDuplicateVote       = errors.New("already voted on this poll")
-	ErrInvalidAudienceUID  = errors.New("invalid audience uid")
-	ErrSingleModeMultiple  = errors.New("single mode polls only allow one option")
-	ErrNoOptions           = errors.New("no options provided")
+	ErrPollNotActive      = errors.New("poll is not active")
+	ErrPollClosed         = errors.New("poll is closed")
+	ErrInvalidOption      = errors.New("invalid option for this poll")
+	ErrDuplicateVote      = errors.New("already voted on this poll")
+	ErrInvalidAudienceUID = errors.New("invalid audience uid")
+	ErrSingleModeMultiple = errors.New("single mode polls only allow one option")
+	ErrNoOptions          = errors.New("no options provided")
 )
 
 type VoteService struct {
 	db  *gorm.DB
 	rdb *redis.Client
+	pub *Publisher
 }
 
-func NewVoteService(db *gorm.DB, rdb *redis.Client) *VoteService {
-	return &VoteService{db: db, rdb: rdb}
+func NewVoteService(db *gorm.DB, rdb *redis.Client, pub *Publisher) *VoteService {
+	return &VoteService{db: db, rdb: rdb, pub: pub}
 }
 
 // CastVote handles voting on a poll with business logic validation.
@@ -116,6 +117,25 @@ func (s *VoteService) CastVote(ctx context.Context, sessionCode string, pollID u
 		if err := s.db.Create(&vote).Error; err != nil {
 			return fmt.Errorf("create vote: %w", err)
 		}
+	}
+
+	// Publish vote_update with full poll state
+	if s.pub != nil {
+		go func() {
+			counts, err := s.GetVoteCounts(pollID)
+			if err != nil {
+				return
+			}
+			var optPayloads []VoteOptionPayload
+			for _, opt := range poll.Options {
+				optPayloads = append(optPayloads, VoteOptionPayload{
+					ID:        opt.ID.String(),
+					Label:     opt.Label,
+					VoteCount: counts[opt.ID],
+				})
+			}
+			s.pub.PublishVoteUpdate(context.Background(), sessionCode, pollID, optPayloads)
+		}()
 	}
 
 	return nil

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -63,11 +63,12 @@ func main() {
 
 	startTime := time.Now()
 	svc := service.New(gormDB, cfg.JWTSecret, cfg.JWTExpiry)
+	pub := service.NewPublisher(rdb)
 	sessionSvc := service.NewSessionService(gormDB, rdb)
 	pollSvc := service.NewPollService(gormDB)
-	voteSvc := service.NewVoteService(gormDB, rdb)
-	qaSvc := service.NewQAService(gormDB, rdb)
-	qaVoteSvc := service.NewQAVoteService(gormDB, rdb)
+	voteSvc := service.NewVoteService(gormDB, rdb, pub)
+	qaSvc := service.NewQAService(gormDB, rdb, pub)
+	qaVoteSvc := service.NewQAVoteService(gormDB, rdb, pub)
 	r := router.New(startTime, svc, sessionSvc, pollSvc, voteSvc, qaSvc, qaVoteSvc, cfg.JWTSecret)
 
 	srv := &http.Server{

--- a/apps/realtime/README.md
+++ b/apps/realtime/README.md
@@ -1,0 +1,332 @@
+# LivePulse — Realtime Service
+
+The Go WebSocket server powering LivePulse's real-time features. Manages WebSocket connections organized into rooms by session code, and bridges Redis Pub/Sub messages to connected browser clients.
+
+## Architecture
+
+```
+                                    ┌──────────────────────────────────┐
+                                    │         Realtime Service         │
+                                    │                                  │
+Browser A ──ws──┐                   │  ┌─────────┐    ┌────────────┐  │
+Browser B ──ws──┤──→ /ws/{code} ──→ │  │   Hub   │◄───│ Subscriber │  │
+Browser C ──ws──┘                   │  │         │    │  (Redis)   │  │
+                                    │  │  Room   │    └──────┬─────┘  │
+Browser D ──ws────→ /ws/{code} ──→  │  │  Room   │           │        │
+                                    │  └─────────┘           │        │
+                                    └────────────────────────┼────────┘
+                                                             │
+                                    ┌────────────────────────┼────────┐
+                                    │         Redis          │        │
+                                    │    channel: session:*   │        │
+                                    └────────────────────────┼────────┘
+                                                             │
+                                    ┌────────────────────────┼────────┐
+                                    │       API Service      │        │
+                                    │      (Publisher)       │        │
+                                    └─────────────────────────────────┘
+```
+
+## Directory Structure
+
+```
+apps/realtime/
+├── main.go                          # Entry point, wires Hub + Subscriber + Redis
+├── Dockerfile
+├── internal/
+│   ├── config/config.go             # Environment-based configuration
+│   ├── handler/
+│   │   ├── health.go                # GET /healthz
+│   │   └── ws.go                    # GET /ws/{code} — WebSocket upgrade handler
+│   ├── hub/
+│   │   ├── hub.go                   # ★ Hub — central room manager + event loop
+│   │   ├── room.go                  # ★ Room — group of clients for one session
+│   │   └── client.go               # ★ Client — single WebSocket connection
+│   ├── message/
+│   │   └── types.go                 # Event type constants
+│   └── pubsub/
+│       └── redis.go                 # ★ Redis Subscriber — per-room channel management
+```
+
+## Environment Variables
+
+| Variable        | Default                      | Description                              |
+| --------------- | ---------------------------- | ---------------------------------------- |
+| `REALTIME_PORT` | `8081`                       | HTTP/WebSocket listen port               |
+| `REDIS_URL`     | `redis://localhost:6379/0`   | Redis connection string                  |
+| `API_BASE_URL`  | `http://localhost:8080`      | API service URL for session validation   |
+
+## Running
+
+```bash
+cd apps/realtime
+go run main.go
+
+# Or with Docker
+docker compose up realtime
+```
+
+## Endpoints
+
+| Method | Path          | Description                                      |
+| ------ | ------------- | ------------------------------------------------ |
+| GET    | `/healthz`    | Health check (JSON: service, status, uptime)     |
+| GET    | `/ws/{code}`  | WebSocket upgrade for a session room             |
+
+---
+
+## WebSocket Connection Lifecycle
+
+### 1. Connection
+
+```
+Browser                          Realtime Service                    API Service
+  │                                    │                                  │
+  │─── GET /ws/A1B2C3 ──────────────▶ │                                  │
+  │    Upgrade: websocket              │                                  │
+  │                                    │─── GET /v1/sessions/A1B2C3 ────▶│
+  │                                    │◄── 200 {status: "active"} ──────│
+  │                                    │                                  │
+  │◄── 101 Switching Protocols ───────│                                  │
+  │                                    │                                  │
+  │    [WebSocket open]                │  Hub.Register(client)            │
+  │                                    │  → Room "A1B2C3" created        │
+  │                                    │  → Redis SUBSCRIBE session:A1B2C3│
+```
+
+### 2. Receiving Events
+
+```
+API Service                     Redis                          Realtime Service           Browser
+  │                               │                                  │                      │
+  │── PUBLISH session:A1B2C3 ──▶ │                                  │                      │
+  │   {type: "vote_update",...}   │── channel message ─────────────▶│                      │
+  │                               │                                  │  Hub.Broadcast       │
+  │                               │                                  │  → Room.broadcast()  │
+  │                               │                                  │  → Client.send chan  │
+  │                               │                                  │── ws text frame ───▶│
+  │                               │                                  │                      │
+```
+
+### 3. Disconnection
+
+```
+Browser                          Realtime Service
+  │                                    │
+  │─── [connection closed] ──────────▶│
+  │                                    │  Hub.Unregister(client)
+  │                                    │  → Room "A1B2C3" has 0 clients
+  │                                    │  → Room destroyed
+  │                                    │  → Redis UNSUBSCRIBE session:A1B2C3
+```
+
+### Rejection Cases
+
+| Scenario                        | Response                                |
+| ------------------------------- | --------------------------------------- |
+| Invalid/unknown session code    | WebSocket close code `4404`             |
+| Session status is `closed`      | WebSocket close code `4404`             |
+| Session status is `archived`    | WebSocket close code `4404`             |
+| API service unreachable         | WebSocket close code `4404`             |
+
+---
+
+## Component Deep Dive
+
+### Hub (`internal/hub/hub.go`)
+
+The Hub is a **single goroutine** running an infinite `select` loop over three channels:
+
+```go
+type Hub struct {
+    rooms      map[string]*Room     // session code → Room
+    register   chan *Client         // new client connected
+    unregister chan *Client         // client disconnected
+    Broadcast  chan BroadcastMessage // message to send to a room
+    subscriber RoomSubscriber       // Redis subscribe/unsubscribe hooks
+}
+```
+
+**Why a single goroutine?** All room mutations (create, destroy, add client, remove client) happen in one goroutine, eliminating the need for mutexes. The `register`, `unregister`, and `Broadcast` channels serialize all operations.
+
+**Room lifecycle hooks:** When a room is created, `subscriber.Subscribe(code)` is called. When destroyed, `subscriber.Unsubscribe(code)`. This ensures Redis subscriptions exactly match active rooms.
+
+### Room (`internal/hub/room.go`)
+
+```go
+type Room struct {
+    Code    string
+    clients map[*Client]bool
+}
+```
+
+- `broadcast(message)` pushes to each client's `send` channel
+- If a client's `send` buffer is full, the client is dropped (prevents slow clients from blocking the room)
+- Logs client count on join/leave for monitoring
+
+### Client (`internal/hub/client.go`)
+
+Each WebSocket connection spawns two goroutines:
+
+```
+                    ┌──────────────┐
+ ws.ReadMessage ◄───│   readPump   │──▶ Hub.unregister (on error/close)
+                    └──────────────┘
+                    ┌──────────────┐
+ ws.WriteMessage ◄──│  writePump   │◀── client.send channel
+                    │              │──▶ ws.PingMessage (every 30s)
+                    └──────────────┘
+```
+
+| Parameter         | Value   | Purpose                                    |
+| ----------------- | ------- | ------------------------------------------ |
+| `sendBufferSize`  | 256     | Buffered `send` channel capacity           |
+| `maxMessageSize`  | 4 KB    | `SetReadLimit` — prevents abuse            |
+| `pingPeriod`      | 30s     | How often server sends ping frames         |
+| `pongWait`        | 60s     | Disconnect if no pong received             |
+| `writeWait`       | 10s     | Deadline for each write operation          |
+
+**readPump** currently logs and discards incoming messages (future phases will add client→server commands).
+
+**writePump** batches queued messages — if multiple messages are in the `send` channel, they're written in a single WebSocket write for efficiency.
+
+### Subscriber (`internal/pubsub/redis.go`)
+
+Manages one Redis Pub/Sub subscription per active room:
+
+```go
+type Subscriber struct {
+    rdb     *redis.Client
+    subs    map[string]*redis.PubSub  // code → subscription
+    handler func(code string, message []byte)
+}
+```
+
+- **`Subscribe(code)`** — Creates a `redis.PubSub` for channel `session:{code}`, starts a goroutine that reads messages and calls the handler. Idempotent — calling twice for the same code is a no-op.
+- **`Unsubscribe(code)`** — Closes the Pub/Sub and removes it from the map.
+- **`Close()`** — Closes all subscriptions on shutdown.
+
+The handler function is wired in `main.go` to push messages into `Hub.Broadcast`:
+
+```go
+sub := pubsub.NewSubscriber(rdb, func(code string, message []byte) {
+    h.Broadcast <- hub.BroadcastMessage{
+        Code:    code,
+        Message: message,
+    }
+})
+```
+
+### Session Validation (`internal/handler/ws.go`)
+
+Before upgrading a WebSocket connection, the handler validates the session by calling the API service:
+
+```
+GET {API_BASE_URL}/v1/sessions/{code}
+```
+
+- **200 + `status: "active"`** → proceed with upgrade
+- **200 + any other status** → reject (close code 4404)
+- **404 or error** → reject (close code 4404)
+
+This keeps the realtime service stateless — it has no database connection and relies on the API as the source of truth.
+
+---
+
+## Redis Pub/Sub — Subscriber Side
+
+### Channel Convention
+
+```
+session:{SESSION_CODE}
+```
+
+Example: `session:A1B2C3`
+
+The API service publishes to this channel. The realtime service subscribes per-room.
+
+### Subscribe/Unsubscribe Lifecycle
+
+| Event                              | Redis Action                          |
+| ---------------------------------- | ------------------------------------- |
+| First client connects to room      | `SUBSCRIBE session:{code}`            |
+| Additional clients join same room  | No action (already subscribed)        |
+| Client disconnects, room not empty | No action (still subscribed)          |
+| Last client disconnects            | `UNSUBSCRIBE session:{code}`          |
+
+This means:
+- Zero clients connected → zero Redis subscriptions → zero overhead
+- 1000 clients in one room → one Redis subscription for that room
+- Each active room = exactly one Redis channel subscription
+
+### Message Flow
+
+```
+Redis channel message
+    │
+    ▼
+Subscriber.handler(code, rawJSON)
+    │
+    ▼
+Hub.Broadcast <- BroadcastMessage{Code, Message}
+    │
+    ▼
+Hub event loop receives on Broadcast channel
+    │
+    ▼
+Room.broadcast(message)
+    │
+    ▼
+For each client in room:
+    client.send <- message  (buffered channel, cap 256)
+    │
+    ▼
+Client.writePump reads from send channel
+    │
+    ▼
+ws.WriteMessage(TextMessage, message)
+    │
+    ▼
+Browser receives WebSocket text frame
+```
+
+The raw JSON from Redis is forwarded **as-is** to WebSocket clients — no parsing or transformation on the realtime side.
+
+### Event Types Received
+
+| Event              | Trigger                              |
+| ------------------ | ------------------------------------ |
+| `vote_update`      | Vote cast on a poll                  |
+| `new_question`     | Audience submitted a question        |
+| `new_comment`      | Audience submitted a comment         |
+| `qa_update`        | Host moderated or audience voted on Q&A |
+| `session_closed`   | Host closed the session              |
+
+See the [API README](../api/README.md) for payload schemas.
+
+---
+
+## Monitoring
+
+The service logs structured JSON to stdout:
+
+```json
+{"time":"...","level":"INFO","msg":"room created","code":"A1B2C3"}
+{"time":"...","level":"INFO","msg":"client joined room","code":"A1B2C3","clients":1}
+{"time":"...","level":"INFO","msg":"subscribed to redis channel","channel":"session:A1B2C3"}
+{"time":"...","level":"INFO","msg":"client joined room","code":"A1B2C3","clients":2}
+{"time":"...","level":"INFO","msg":"client left room","code":"A1B2C3","clients":1}
+{"time":"...","level":"INFO","msg":"client left room","code":"A1B2C3","clients":0}
+{"time":"...","level":"INFO","msg":"room destroyed","code":"A1B2C3"}
+{"time":"...","level":"INFO","msg":"unsubscribed from redis channel","channel":"session:A1B2C3"}
+```
+
+---
+
+## Load Testing
+
+A browser-based load test tool is available at `/load-test.html` (served from `apps/web/public/`).
+
+It connects a WebSocket, then fires N votes (each with a unique audience UID) at configurable delay, displaying a live-updating bar chart as `vote_update` events stream back through the WebSocket.
+
+See [load-test.html](../../apps/web/public/load-test.html) for details.

--- a/apps/realtime/go.mod
+++ b/apps/realtime/go.mod
@@ -3,6 +3,13 @@ module github.com/Eahtasham/live-pulse/apps/realtime
 go 1.25.5
 
 require (
-	github.com/go-chi/chi/v5 v5.2.1 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/go-chi/chi/v5 v5.2.1
+	github.com/gorilla/websocket v1.5.3
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/redis/go-redis/v9 v9.18.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/apps/realtime/go.mod
+++ b/apps/realtime/go.mod
@@ -1,3 +1,8 @@
 module github.com/Eahtasham/live-pulse/apps/realtime
 
 go 1.25.5
+
+require (
+	github.com/go-chi/chi/v5 v5.2.1 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+)

--- a/apps/realtime/go.sum
+++ b/apps/realtime/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/apps/realtime/go.sum
+++ b/apps/realtime/go.sum
@@ -1,4 +1,12 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
+github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=

--- a/apps/realtime/internal/config/config.go
+++ b/apps/realtime/internal/config/config.go
@@ -5,12 +5,14 @@ import "os"
 type Config struct {
 	RealtimePort string
 	RedisURL     string
+	APIBaseURL   string
 }
 
 func Load() *Config {
 	return &Config{
 		RealtimePort: getEnv("REALTIME_PORT", "8081"),
 		RedisURL:     getEnv("REDIS_URL", "redis://localhost:6379/0"),
+		APIBaseURL:   getEnv("API_BASE_URL", "http://localhost:8080"),
 	}
 }
 

--- a/apps/realtime/internal/handler/ws.go
+++ b/apps/realtime/internal/handler/ws.go
@@ -1,1 +1,115 @@
 package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+
+	"github.com/Eahtasham/live-pulse/apps/realtime/internal/hub"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin: func(r *http.Request) bool {
+		// TODO: Restrict origins in production
+		return true
+	},
+}
+
+// WebSocket handles WebSocket upgrade requests.
+// @Summary Connect to a session via WebSocket
+// @Description Upgrades the HTTP connection to a WebSocket for real-time updates on a session.
+// @Description The client will receive broadcast messages for votes, Q&A, and session events.
+// @Description
+// @Description **Message format (server → client):**
+// @Description ```json
+// @Description {"event": "vote_update", "data": {...}}
+// @Description {"event": "new_question", "data": {...}}
+// @Description {"event": "session_closed", "data": {...}}
+// @Description ```
+// @Description
+// @Description **Events:** vote_update, new_question, new_comment, qa_update, session_closed
+// @Description
+// @Description **Close codes:** 4404 = session not found or not active
+// @Tags realtime
+// @Param code path string true "Session code (e.g. A1B2C3)"
+// @Success 101 {string} string "Switching Protocols"
+// @Failure 400 {string} string "Missing session code"
+// @Failure 404 {string} string "Session not found or not active"
+// @Failure 426 {string} string "WebSocket upgrade required"
+// @Router /ws/{code} [get]
+func WebSocket(h *hub.Hub, apiBaseURL string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		code := chi.URLParam(r, "code")
+		if code == "" {
+			http.Error(w, "missing session code", http.StatusBadRequest)
+			return
+		}
+
+		// Validate session exists and is active via API service
+		if err := validateSession(apiBaseURL, code); err != nil {
+			slog.Warn("session validation failed", "code", code, "error", err)
+			// If this is already a WebSocket upgrade attempt, reject with close code
+			conn, upgradeErr := upgrader.Upgrade(w, r, nil)
+			if upgradeErr != nil {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			conn.WriteMessage(websocket.CloseMessage,
+				websocket.FormatCloseMessage(4404, err.Error()))
+			conn.Close()
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			slog.Error("websocket upgrade failed", "code", code, "error", err)
+			return
+		}
+
+		client := hub.NewClient(h, conn, code)
+		h.Register(client)
+
+		go client.WritePump()
+		go client.ReadPump()
+	}
+}
+
+type sessionAPIResponse struct {
+	Status string `json:"status"`
+}
+
+func validateSession(apiBaseURL, code string) error {
+	url := fmt.Sprintf("%s/v1/sessions/code/%s", apiBaseURL, code)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to validate session: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("session not found")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("session validation returned status %d", resp.StatusCode)
+	}
+
+	var session sessionAPIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&session); err != nil {
+		return fmt.Errorf("failed to decode session response: %w", err)
+	}
+
+	if session.Status != "active" {
+		return fmt.Errorf("session is %s, not active", session.Status)
+	}
+
+	return nil
+}

--- a/apps/realtime/internal/handler/ws.go
+++ b/apps/realtime/internal/handler/ws.go
@@ -86,7 +86,7 @@ type sessionAPIResponse struct {
 }
 
 func validateSession(apiBaseURL, code string) error {
-	url := fmt.Sprintf("%s/v1/sessions/code/%s", apiBaseURL, code)
+	url := fmt.Sprintf("%s/v1/sessions/%s", apiBaseURL, code)
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(url)

--- a/apps/realtime/internal/hub/client.go
+++ b/apps/realtime/internal/hub/client.go
@@ -1,1 +1,114 @@
 package hub
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = 30 * time.Second
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 4096
+
+	// Send channel buffer size.
+	sendBufferSize = 256
+)
+
+// Client represents a single WebSocket connection.
+type Client struct {
+	hub  *Hub
+	conn *websocket.Conn
+	send chan []byte
+	code string // session code this client belongs to
+}
+
+// NewClient creates a new Client.
+func NewClient(hub *Hub, conn *websocket.Conn, code string) *Client {
+	return &Client{
+		hub:  hub,
+		conn: conn,
+		send: make(chan []byte, sendBufferSize),
+		code: code,
+	}
+}
+
+// ReadPump pumps messages from the WebSocket connection to the hub.
+func (c *Client) ReadPump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+
+	c.conn.SetReadLimit(maxMessageSize)
+	c.conn.SetReadDeadline(time.Now().Add(pongWait))
+	c.conn.SetPongHandler(func(string) error {
+		c.conn.SetReadDeadline(time.Now().Add(pongWait))
+		return nil
+	})
+
+	for {
+		_, message, err := c.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				slog.Warn("websocket read error", "code", c.code, "error", err)
+			}
+			break
+		}
+		// Log and discard incoming messages for now (Phase 9 will add handlers)
+		slog.Debug("received message from client", "code", c.code, "size", len(message))
+	}
+}
+
+// WritePump pumps messages from the hub to the WebSocket connection.
+func (c *Client) WritePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+
+	for {
+		select {
+		case message, ok := <-c.send:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if !ok {
+				// Hub closed the channel.
+				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				return
+			}
+
+			w, err := c.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				return
+			}
+			w.Write(message)
+
+			// Drain queued messages into the current write.
+			n := len(c.send)
+			for i := 0; i < n; i++ {
+				w.Write([]byte{'\n'})
+				w.Write(<-c.send)
+			}
+
+			if err := w.Close(); err != nil {
+				return
+			}
+
+		case <-ticker.C:
+			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/apps/realtime/internal/hub/hub.go
+++ b/apps/realtime/internal/hub/hub.go
@@ -8,21 +8,29 @@ type BroadcastMessage struct {
 	Message []byte
 }
 
+// RoomSubscriber is called when rooms are created/destroyed for Pub/Sub wiring.
+type RoomSubscriber interface {
+	Subscribe(code string)
+	Unsubscribe(code string)
+}
+
 // Hub maintains the set of active rooms and routes messages.
 type Hub struct {
 	rooms      map[string]*Room
 	register   chan *Client
 	unregister chan *Client
 	Broadcast  chan BroadcastMessage
+	subscriber RoomSubscriber
 }
 
 // NewHub creates and returns a new Hub.
-func NewHub() *Hub {
+func NewHub(subscriber RoomSubscriber) *Hub {
 	return &Hub{
 		rooms:      make(map[string]*Room),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		Broadcast:  make(chan BroadcastMessage),
+		subscriber: subscriber,
 	}
 }
 
@@ -36,6 +44,9 @@ func (h *Hub) Run() {
 				room = newRoom(client.code)
 				h.rooms[client.code] = room
 				slog.Info("room created", "code", client.code)
+				if h.subscriber != nil {
+					h.subscriber.Subscribe(client.code)
+				}
 			}
 			room.add(client)
 
@@ -49,6 +60,9 @@ func (h *Hub) Run() {
 			if room.isEmpty() {
 				delete(h.rooms, client.code)
 				slog.Info("room destroyed", "code", client.code)
+				if h.subscriber != nil {
+					h.subscriber.Unsubscribe(client.code)
+				}
 			}
 
 		case msg := <-h.Broadcast:

--- a/apps/realtime/internal/hub/hub.go
+++ b/apps/realtime/internal/hub/hub.go
@@ -1,1 +1,81 @@
 package hub
+
+import "log/slog"
+
+// BroadcastMessage carries a message to be sent to all clients in a room.
+type BroadcastMessage struct {
+	Code    string
+	Message []byte
+}
+
+// Hub maintains the set of active rooms and routes messages.
+type Hub struct {
+	rooms      map[string]*Room
+	register   chan *Client
+	unregister chan *Client
+	Broadcast  chan BroadcastMessage
+}
+
+// NewHub creates and returns a new Hub.
+func NewHub() *Hub {
+	return &Hub{
+		rooms:      make(map[string]*Room),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		Broadcast:  make(chan BroadcastMessage),
+	}
+}
+
+// Run starts the hub's main event loop. Should be called as a goroutine.
+func (h *Hub) Run() {
+	for {
+		select {
+		case client := <-h.register:
+			room, ok := h.rooms[client.code]
+			if !ok {
+				room = newRoom(client.code)
+				h.rooms[client.code] = room
+				slog.Info("room created", "code", client.code)
+			}
+			room.add(client)
+
+		case client := <-h.unregister:
+			room, ok := h.rooms[client.code]
+			if !ok {
+				continue
+			}
+			room.remove(client)
+			close(client.send)
+			if room.isEmpty() {
+				delete(h.rooms, client.code)
+				slog.Info("room destroyed", "code", client.code)
+			}
+
+		case msg := <-h.Broadcast:
+			room, ok := h.rooms[msg.Code]
+			if !ok {
+				continue
+			}
+			room.broadcast(msg.Message)
+		}
+	}
+}
+
+// Register adds a client to the hub.
+func (h *Hub) Register(c *Client) {
+	h.register <- c
+}
+
+// RoomCount returns the number of active rooms (for testing/monitoring).
+func (h *Hub) RoomCount() int {
+	return len(h.rooms)
+}
+
+// ClientCount returns the number of clients in a specific room.
+func (h *Hub) ClientCount(code string) int {
+	room, ok := h.rooms[code]
+	if !ok {
+		return 0
+	}
+	return room.count()
+}

--- a/apps/realtime/internal/hub/room.go
+++ b/apps/realtime/internal/hub/room.go
@@ -1,1 +1,48 @@
 package hub
+
+import "log/slog"
+
+// Room represents a group of clients connected to the same session.
+type Room struct {
+	Code    string
+	clients map[*Client]bool
+}
+
+func newRoom(code string) *Room {
+	return &Room{
+		Code:    code,
+		clients: make(map[*Client]bool),
+	}
+}
+
+func (r *Room) add(c *Client) {
+	r.clients[c] = true
+	slog.Info("client joined room", "code", r.Code, "clients", len(r.clients))
+}
+
+func (r *Room) remove(c *Client) {
+	if _, ok := r.clients[c]; ok {
+		delete(r.clients, c)
+		slog.Info("client left room", "code", r.Code, "clients", len(r.clients))
+	}
+}
+
+func (r *Room) broadcast(message []byte) {
+	for c := range r.clients {
+		select {
+		case c.send <- message:
+		default:
+			// Client send buffer full — drop the client
+			close(c.send)
+			delete(r.clients, c)
+		}
+	}
+}
+
+func (r *Room) isEmpty() bool {
+	return len(r.clients) == 0
+}
+
+func (r *Room) count() int {
+	return len(r.clients)
+}

--- a/apps/realtime/internal/pubsub/redis.go
+++ b/apps/realtime/internal/pubsub/redis.go
@@ -1,1 +1,114 @@
 package pubsub
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Subscriber manages Redis Pub/Sub subscriptions for session rooms.
+// It subscribes to channels when the first client joins a room
+// and unsubscribes when the last client leaves.
+type Subscriber struct {
+	rdb     *redis.Client
+	mu      sync.Mutex
+	subs    map[string]*redis.PubSub // keyed by session code
+	handler func(code string, message []byte)
+}
+
+// NewSubscriber creates a new Subscriber.
+// handler is called with the session code and raw message bytes for each received message.
+func NewSubscriber(rdb *redis.Client, handler func(code string, message []byte)) *Subscriber {
+	return &Subscriber{
+		rdb:     rdb,
+		subs:    make(map[string]*redis.PubSub),
+		handler: handler,
+	}
+}
+
+// Subscribe subscribes to the Redis channel for a session code.
+// Safe to call multiple times for the same code — only the first call creates a subscription.
+func (s *Subscriber) Subscribe(code string) {
+	s.mu.Lock()
+	if _, ok := s.subs[code]; ok {
+		s.mu.Unlock()
+		return // already subscribed
+	}
+
+	channel := "session:" + code
+	pubsub := s.rdb.Subscribe(context.Background(), channel)
+	s.subs[code] = pubsub
+	s.mu.Unlock()
+
+	slog.Info("subscribed to redis channel", "channel", channel)
+
+	// Listen for messages in a goroutine
+	go func() {
+		ch := pubsub.Channel()
+		for msg := range ch {
+			slog.Debug("received redis message", "channel", msg.Channel, "size", len(msg.Payload))
+			s.handler(code, []byte(msg.Payload))
+		}
+		slog.Info("redis channel closed", "channel", channel)
+	}()
+}
+
+// Unsubscribe unsubscribes from the Redis channel for a session code.
+func (s *Subscriber) Unsubscribe(code string) {
+	s.mu.Lock()
+	pubsub, ok := s.subs[code]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.subs, code)
+	s.mu.Unlock()
+
+	channel := "session:" + code
+	if err := pubsub.Close(); err != nil {
+		slog.Error("failed to close redis subscription", "channel", channel, "error", err)
+	} else {
+		slog.Info("unsubscribed from redis channel", "channel", channel)
+	}
+}
+
+// Close closes all active subscriptions.
+func (s *Subscriber) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var firstErr error
+	for code, pubsub := range s.subs {
+		if err := pubsub.Close(); err != nil {
+			slog.Error("failed to close subscription", "code", code, "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	s.subs = make(map[string]*redis.PubSub)
+
+	if firstErr != nil {
+		return fmt.Errorf("close subscriptions: %w", firstErr)
+	}
+	return nil
+}
+
+// NewRedisClient creates a Redis client from a URL.
+func NewRedisClient(redisURL string) (*redis.Client, error) {
+	opts, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid redis url: %w", err)
+	}
+
+	rdb := redis.NewClient(opts)
+
+	if err := rdb.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("unable to ping redis: %w", err)
+	}
+
+	return rdb, nil
+}

--- a/apps/realtime/main.go
+++ b/apps/realtime/main.go
@@ -9,8 +9,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/Eahtasham/live-pulse/apps/realtime/internal/config"
 	"github.com/Eahtasham/live-pulse/apps/realtime/internal/handler"
+	"github.com/Eahtasham/live-pulse/apps/realtime/internal/hub"
 )
 
 func main() {
@@ -21,17 +24,21 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
+	// Start the WebSocket hub
+	h := hub.NewHub()
+	go h.Run()
+
 	startTime := time.Now()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", handler.Health(startTime))
+	r := chi.NewRouter()
+	r.Get("/healthz", handler.Health(startTime))
+	r.Get("/ws/{code}", handler.WebSocket(h, cfg.APIBaseURL))
 
 	srv := &http.Server{
-		Addr:         ":" + cfg.RealtimePort,
-		Handler:      mux,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
-		IdleTimeout:  60 * time.Second,
+		Addr:        ":" + cfg.RealtimePort,
+		Handler:     r,
+		ReadTimeout: 15 * time.Second,
+		IdleTimeout: 60 * time.Second,
 	}
 
 	done := make(chan os.Signal, 1)

--- a/apps/realtime/main.go
+++ b/apps/realtime/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Eahtasham/live-pulse/apps/realtime/internal/config"
 	"github.com/Eahtasham/live-pulse/apps/realtime/internal/handler"
 	"github.com/Eahtasham/live-pulse/apps/realtime/internal/hub"
+	"github.com/Eahtasham/live-pulse/apps/realtime/internal/pubsub"
 )
 
 func main() {
@@ -24,8 +25,25 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
-	// Start the WebSocket hub
-	h := hub.NewHub()
+	// Connect to Redis
+	rdb, err := pubsub.NewRedisClient(cfg.RedisURL)
+	if err != nil {
+		slog.Error("failed to connect to redis", "error", err)
+		os.Exit(1)
+	}
+	defer rdb.Close()
+
+	// Create hub with subscriber that broadcasts Redis messages to rooms
+	var h *hub.Hub
+	sub := pubsub.NewSubscriber(rdb, func(code string, message []byte) {
+		h.Broadcast <- hub.BroadcastMessage{
+			Code:    code,
+			Message: message,
+		}
+	})
+	defer sub.Close()
+
+	h = hub.NewHub(sub)
 	go h.Run()
 
 	startTime := time.Now()

--- a/apps/web/public/load-test.html
+++ b/apps/web/public/load-test.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>LivePulse — WebSocket Load Test</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; padding: 24px; background: #0f172a; color: #e2e8f0; }
+    h1 { margin-bottom: 16px; }
+    .panel { background: #1e293b; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+    label { display: block; margin-bottom: 4px; font-size: 14px; color: #94a3b8; }
+    input, select { background: #0f172a; border: 1px solid #334155; color: #e2e8f0; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; width: 100%; }
+    button { background: #3b82f6; color: white; border: none; padding: 10px 20px; border-radius: 6px; cursor: pointer; font-size: 14px; margin-right: 8px; }
+    button:hover { background: #2563eb; }
+    button:disabled { background: #475569; cursor: not-allowed; }
+    button.danger { background: #ef4444; }
+    button.danger:hover { background: #dc2626; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 12px 0; }
+    .stat { background: #0f172a; padding: 12px; border-radius: 6px; text-align: center; }
+    .stat .value { font-size: 28px; font-weight: bold; color: #3b82f6; }
+    .stat .label { font-size: 12px; color: #94a3b8; margin-top: 4px; }
+    #log { background: #0f172a; border: 1px solid #334155; border-radius: 4px; padding: 12px; max-height: 300px; overflow-y: auto; font-family: monospace; font-size: 12px; line-height: 1.6; }
+    .log-vote { color: #22c55e; }
+    .log-ws { color: #3b82f6; }
+    .log-error { color: #ef4444; }
+    .log-info { color: #94a3b8; }
+    .chart-bar { display: flex; align-items: center; margin: 4px 0; }
+    .chart-bar .bar-label { width: 120px; font-size: 13px; }
+    .chart-bar .bar-track { flex: 1; height: 28px; background: #1e293b; border-radius: 4px; overflow: hidden; position: relative; }
+    .chart-bar .bar-fill { height: 100%; background: #3b82f6; transition: width 0.15s ease; border-radius: 4px; }
+    .chart-bar .bar-count { width: 60px; text-align: right; font-size: 13px; font-weight: bold; }
+    #chart { margin: 12px 0; }
+    .flex { display: flex; gap: 8px; align-items: end; }
+    .flex > div { flex: 1; }
+  </style>
+</head>
+<body>
+  <h1>🔴 LivePulse — WebSocket Load Test</h1>
+
+  <div class="panel">
+    <h3 style="margin-bottom: 12px;">Setup</h3>
+    <div class="flex">
+      <div>
+        <label>API Base URL</label>
+        <input id="apiUrl" value="http://localhost:8080" />
+      </div>
+      <div>
+        <label>Realtime WS URL</label>
+        <input id="wsUrl" value="ws://localhost:8081" />
+      </div>
+      <div>
+        <label>Session Code</label>
+        <input id="sessionCode" placeholder="e.g. A1B2C3" />
+      </div>
+    </div>
+    <div class="flex">
+      <div>
+        <label>Poll ID</label>
+        <input id="pollId" placeholder="UUID of the poll" />
+      </div>
+      <div>
+        <label>Number of Votes</label>
+        <input id="numVotes" type="number" value="1000" min="1" max="10000" />
+      </div>
+      <div>
+        <label>Delay Between Votes (ms)</label>
+        <input id="voteDelay" type="number" value="50" min="0" max="5000" />
+      </div>
+    </div>
+    <button id="btnConnect" onclick="connectWS()">1. Connect WebSocket</button>
+    <button id="btnLoadPoll" onclick="loadPoll()">2. Load Poll</button>
+    <button id="btnStart" onclick="startLoadTest()" disabled>3. Start Load Test</button>
+    <button id="btnStop" class="danger" onclick="stopLoadTest()" disabled>Stop</button>
+  </div>
+
+  <div class="panel">
+    <h3>Live Results</h3>
+    <div id="chart"></div>
+    <div class="stats">
+      <div class="stat"><div class="value" id="statSent">0</div><div class="label">Votes Sent</div></div>
+      <div class="stat"><div class="value" id="statReceived">0</div><div class="label">WS Events</div></div>
+      <div class="stat"><div class="value" id="statErrors">0</div><div class="label">Errors</div></div>
+      <div class="stat"><div class="value" id="statAvgLatency">-</div><div class="label">Avg Latency</div></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <h3 style="margin-bottom: 8px;">Log</h3>
+    <div id="log"></div>
+  </div>
+
+  <script>
+    let ws = null;
+    let pollOptions = [];
+    let running = false;
+    let abortController = null;
+
+    let stats = { sent: 0, received: 0, errors: 0, latencies: [] };
+
+    function log(msg, cls = 'log-info') {
+      const el = document.getElementById('log');
+      const line = document.createElement('div');
+      line.className = cls;
+      line.textContent = `[${new Date().toISOString().slice(11, 23)}] ${msg}`;
+      el.appendChild(line);
+      el.scrollTop = el.scrollHeight;
+    }
+
+    function updateStats() {
+      document.getElementById('statSent').textContent = stats.sent;
+      document.getElementById('statReceived').textContent = stats.received;
+      document.getElementById('statErrors').textContent = stats.errors;
+      if (stats.latencies.length > 0) {
+        const avg = stats.latencies.reduce((a, b) => a + b, 0) / stats.latencies.length;
+        document.getElementById('statAvgLatency').textContent = Math.round(avg) + 'ms';
+      }
+    }
+
+    function renderChart(options) {
+      const maxCount = Math.max(...options.map(o => o.vote_count), 1);
+      const chart = document.getElementById('chart');
+      chart.innerHTML = options.map(o => `
+        <div class="chart-bar">
+          <div class="bar-label">${o.label}</div>
+          <div class="bar-track">
+            <div class="bar-fill" style="width: ${(o.vote_count / maxCount) * 100}%"></div>
+          </div>
+          <div class="bar-count">${o.vote_count}</div>
+        </div>
+      `).join('');
+    }
+
+    function connectWS() {
+      const wsUrl = document.getElementById('wsUrl').value;
+      const code = document.getElementById('sessionCode').value;
+      if (!code) { alert('Enter session code'); return; }
+
+      if (ws) ws.close();
+
+      ws = new WebSocket(`${wsUrl}/ws/${code}`);
+      ws.onopen = () => {
+        log('WebSocket connected', 'log-ws');
+        document.getElementById('btnLoadPoll').disabled = false;
+      };
+      ws.onmessage = (e) => {
+        stats.received++;
+        try {
+          const data = JSON.parse(e.data);
+          if (data.type === 'vote_update' && data.payload) {
+            renderChart(data.payload.options);
+            log(`vote_update: ${data.payload.options.map(o => `${o.label}=${o.vote_count}`).join(', ')}`, 'log-ws');
+          } else {
+            log(`event: ${data.type}`, 'log-ws');
+          }
+        } catch {
+          log(`raw message: ${e.data}`, 'log-ws');
+        }
+        updateStats();
+      };
+      ws.onclose = (e) => log(`WebSocket closed: code=${e.code}`, 'log-ws');
+      ws.onerror = () => log('WebSocket error', 'log-error');
+    }
+
+    async function loadPoll() {
+      const apiUrl = document.getElementById('apiUrl').value;
+      const code = document.getElementById('sessionCode').value;
+      const pollId = document.getElementById('pollId').value;
+
+      if (!pollId) {
+        // Try to list polls and pick the first active one
+        try {
+          const resp = await fetch(`${apiUrl}/v1/sessions/${code}/polls`);
+          const data = await resp.json();
+          const polls = data.polls || data;
+          const active = polls.find(p => p.status === 'active');
+          if (active) {
+            document.getElementById('pollId').value = active.id;
+            pollOptions = active.options;
+            log(`Found active poll: "${active.question}" with ${active.options.length} options`, 'log-info');
+            renderChart(pollOptions.map(o => ({ label: o.label, vote_count: 0 })));
+            document.getElementById('btnStart').disabled = false;
+            return;
+          }
+          log('No active poll found. Create one and set its status to "active".', 'log-error');
+        } catch (err) {
+          log(`Failed to load polls: ${err.message}`, 'log-error');
+        }
+        return;
+      }
+
+      try {
+        const resp = await fetch(`${apiUrl}/v1/sessions/${code}/polls/${pollId}`);
+        const poll = await resp.json();
+        pollOptions = poll.options;
+        log(`Loaded poll: "${poll.question}" with ${poll.options.length} options`, 'log-info');
+        renderChart(pollOptions.map(o => ({ label: o.label, vote_count: 0 })));
+        document.getElementById('btnStart').disabled = false;
+      } catch (err) {
+        log(`Failed to load poll: ${err.message}`, 'log-error');
+      }
+    }
+
+    async function startLoadTest() {
+      const apiUrl = document.getElementById('apiUrl').value;
+      const code = document.getElementById('sessionCode').value;
+      const pollId = document.getElementById('pollId').value;
+      const numVotes = parseInt(document.getElementById('numVotes').value);
+      const delay = parseInt(document.getElementById('voteDelay').value);
+
+      if (!pollId || pollOptions.length === 0) {
+        log('Load poll first', 'log-error');
+        return;
+      }
+
+      running = true;
+      abortController = new AbortController();
+      stats = { sent: 0, received: 0, errors: 0, latencies: [] };
+      updateStats();
+
+      document.getElementById('btnStart').disabled = true;
+      document.getElementById('btnStop').disabled = false;
+
+      log(`Starting load test: ${numVotes} votes, ${delay}ms delay`, 'log-info');
+
+      for (let i = 0; i < numVotes && running; i++) {
+        // First join the session to get a unique audience_uid
+        try {
+          const joinResp = await fetch(`${apiUrl}/v1/sessions/${code}/join`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-Client-ID': `loadtest-${Date.now()}-${i}` },
+            signal: abortController.signal,
+          });
+          const joinData = await joinResp.json();
+          const audienceUID = joinData.audience_uid;
+
+          // Pick random option
+          const randomOption = pollOptions[Math.floor(Math.random() * pollOptions.length)];
+
+          const start = performance.now();
+          const voteResp = await fetch(`${apiUrl}/v1/sessions/${code}/polls/${pollId}/vote`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              option_ids: [randomOption.id],
+              audience_uid: audienceUID,
+            }),
+            signal: abortController.signal,
+          });
+          const elapsed = performance.now() - start;
+          stats.latencies.push(elapsed);
+
+          if (voteResp.ok) {
+            stats.sent++;
+            if (stats.sent % 100 === 0 || stats.sent === numVotes) {
+              log(`Vote ${stats.sent}/${numVotes}: ${randomOption.label} (${Math.round(elapsed)}ms)`, 'log-vote');
+            }
+          } else {
+            const errData = await voteResp.json();
+            stats.errors++;
+            if (stats.errors <= 10) {
+              log(`Vote ${i + 1} failed: ${errData.message || voteResp.status}`, 'log-error');
+            }
+          }
+        } catch (err) {
+          if (err.name === 'AbortError') break;
+          stats.errors++;
+          log(`Vote ${i + 1} error: ${err.message}`, 'log-error');
+        }
+
+        updateStats();
+
+        if (delay > 0 && running) {
+          await new Promise(r => setTimeout(r, delay));
+        }
+      }
+
+      running = false;
+      document.getElementById('btnStart').disabled = false;
+      document.getElementById('btnStop').disabled = true;
+      log(`Load test finished. Sent: ${stats.sent}, Received: ${stats.received}, Errors: ${stats.errors}`, 'log-info');
+    }
+
+    function stopLoadTest() {
+      running = false;
+      if (abortController) abortController.abort();
+      document.getElementById('btnStart').disabled = false;
+      document.getElementById('btnStop').disabled = true;
+      log('Load test stopped by user', 'log-info');
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION


- API: add Publisher service that publishes vote_update, new_question,
  new_comment, qa_update, and session_closed events to Redis channels
- API: wire publisher into VoteService, QAService, and QAVoteService
- Realtime: add Redis Subscriber with per-room channel management
- Realtime: wire subscriber into Hub for auto subscribe/unsubscribe
  on room create/destroy
- Realtime: fix session validation URL and remove WriteTimeout
- Add READMEs for both API and realtime services
- Add browser-based WebSocket load test tool

closes #9  and closes #10 